### PR TITLE
Add title audio url to true false games ss-069

### DIFF
--- a/laravel/app/Enums/Tts/TtsModelMappingEnum.php
+++ b/laravel/app/Enums/Tts/TtsModelMappingEnum.php
@@ -2,6 +2,7 @@
 
 namespace App\Enums\Tts;
 
+use App\Games\TrueFalseImage\Models\TrueFalseImageLevel;
 use App\Games\TrueFalseImage\Models\TrueFalseImageStatement;
 use App\Games\TrueFalseText\Models\TrueFalseTextLevel;
 use App\Games\TrueFalseText\Models\TrueFalseTextStatement;
@@ -11,6 +12,7 @@ enum TtsModelMappingEnum: string
     case TRUE_FALSE_TEXT_STATEMENT = TrueFalseTextStatement::class;
     case TRUE_FALSE_IMAGE_STATEMENT = TrueFalseImageStatement::class;
     case TRUE_FALSE_TEXT_LEVEL = TrueFalseTextLevel::class;
+    case TRUE_FALSE_IMAGE_LEVEL = TrueFalseImageLevel::class;
 
     /**
      * Get the game type identifier for storage paths.
@@ -18,9 +20,10 @@ enum TtsModelMappingEnum: string
     public function getGameType(): string
     {
         return match ($this) {
-            self::TRUE_FALSE_TEXT_STATEMENT => 'true_false_text',
-            self::TRUE_FALSE_IMAGE_STATEMENT => 'true_false_image',
+            self::TRUE_FALSE_TEXT_STATEMENT,
             self::TRUE_FALSE_TEXT_LEVEL => 'true_false_text',
+            self::TRUE_FALSE_IMAGE_STATEMENT,
+            self::TRUE_FALSE_IMAGE_LEVEL => 'true_false_image',
         };
     }
 
@@ -32,7 +35,8 @@ enum TtsModelMappingEnum: string
         return match ($this) {
             self::TRUE_FALSE_TEXT_STATEMENT,
             self::TRUE_FALSE_IMAGE_STATEMENT => 'statements',
-            self::TRUE_FALSE_TEXT_LEVEL => 'levels',
+            self::TRUE_FALSE_TEXT_LEVEL,
+            self::TRUE_FALSE_IMAGE_LEVEL => 'levels',
         };
     }
 

--- a/laravel/app/Games/TrueFalseImage/Http/Resources/TrueFalseImageLevelResource.php
+++ b/laravel/app/Games/TrueFalseImage/Http/Resources/TrueFalseImageLevelResource.php
@@ -5,6 +5,7 @@ namespace App\Games\TrueFalseImage\Http\Resources;
 use App\Facades\Tts;
 use App\Games\TrueFalseImage\Models\TrueFalseImageLevel;
 use App\Services\Tts\DTO\TtsAudioContext;
+use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class TrueFalseImageLevelResource extends JsonResource
@@ -47,10 +48,9 @@ class TrueFalseImageLevelResource extends JsonResource
      *     )
      * )
      *
-     * @param  \Illuminate\Http\Request  $request
      * @return array<string,mixed>
      */
-    public function toArray($request): array
+    public function toArray(Request $request): array
     {
         /** @var TrueFalseImageLevel $level */
         $level = $this->resource;

--- a/laravel/app/Games/TrueFalseImage/Http/Resources/TrueFalseImageLevelResource.php
+++ b/laravel/app/Games/TrueFalseImage/Http/Resources/TrueFalseImageLevelResource.php
@@ -2,7 +2,9 @@
 
 namespace App\Games\TrueFalseImage\Http\Resources;
 
+use App\Facades\Tts;
 use App\Games\TrueFalseImage\Models\TrueFalseImageLevel;
+use App\Services\Tts\DTO\TtsAudioContext;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class TrueFalseImageLevelResource extends JsonResource
@@ -25,6 +27,13 @@ class TrueFalseImageLevelResource extends JsonResource
      *         description="The level title"
      *     ),
      *     @OA\Property(
+     *         property="title_audio_url",
+     *         type="string",
+     *         format="uri",
+     *         nullable=true,
+     *         description="Audio URL for the level title"
+     *     ),
+     *     @OA\Property(
      *         property="image_url",
      *         type="string",
      *         description="The level image URL"
@@ -43,13 +52,16 @@ class TrueFalseImageLevelResource extends JsonResource
      */
     public function toArray($request): array
     {
-
         /** @var TrueFalseImageLevel $level */
         $level = $this->resource;
+        $locale = app()->getLocale();
 
         return [
             'id' => $level->id,
             'title' => $level->title,
+            'title_audio_url' => Tts::getOrGenerate(
+                TtsAudioContext::make($level, 'title_audio_url', $locale)
+            ),
             'image_url' => $level->image_url,
             'statements' => TrueFalseImageStatementResource::collection($this->whenLoaded('statements')),
         ];

--- a/laravel/app/Games/TrueFalseImage/Models/TrueFalseImageLevel.php
+++ b/laravel/app/Games/TrueFalseImage/Models/TrueFalseImageLevel.php
@@ -2,25 +2,34 @@
 
 namespace App\Games\TrueFalseImage\Models;
 
+use App\Contracts\TtsAudioInterface;
 use App\Models\Level;
+use App\Traits\HasTtsAudio;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Spatie\Translatable\HasTranslations;
 
-class TrueFalseImageLevel extends Level
+class TrueFalseImageLevel extends Level implements TtsAudioInterface
 {
     use HasFactory;
     use HasTranslations;
+    use HasTtsAudio;
 
     protected $table = 'true_false_image_levels';
 
     protected $fillable = [
         'title',
         'image_url',
+        'title_audio_url',
+    ];
+
+    protected $attributes = [
+        'title' => '{}',
+        'title_audio_url' => '{}',
     ];
 
     /** @var array<int, string> */
-    public $translatable = ['title'];
+    public $translatable = ['title', 'title_audio_url'];
 
     public function statements(): HasMany
     {

--- a/laravel/app/Games/TrueFalseText/Http/Resources/TrueFalseTextLevelResource.php
+++ b/laravel/app/Games/TrueFalseText/Http/Resources/TrueFalseTextLevelResource.php
@@ -34,7 +34,6 @@ class TrueFalseTextLevelResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
-
         /** @var TrueFalseTextLevel $level */
         $level = $this->resource;
         $locale = app()->getLocale();

--- a/laravel/app/Games/TrueFalseText/Http/Resources/TrueFalseTextLevelResource.php
+++ b/laravel/app/Games/TrueFalseText/Http/Resources/TrueFalseTextLevelResource.php
@@ -20,6 +20,7 @@ class TrueFalseTextLevelResource extends JsonResource
      *
      *     @OA\Property(property="id", type="integer", example=1, description="Level ID"),
      *     @OA\Property(property="title", type="string", example="Level 1", description="Level title"),
+     *     @OA\Property(property="title_audio_url", type="string", format="uri", nullable=true, example="https://example.com/audio/title_uk.mp3", description="Title audio URL"),
      *     @OA\Property(property="image_url", type="string", example="https://example.com/image.png", description="Level image URL"),
      *     @OA\Property(property="text", type="string", example="Some introductory text", description="Level text"),
      *     @OA\Property(property="text_audio_url", type="string", format="uri", nullable=true, example="https://example.com/audio/text_uk.mp3", description="Text audio URL"),
@@ -41,6 +42,9 @@ class TrueFalseTextLevelResource extends JsonResource
         return [
             'id' => $level->id,
             'title' => $level->title,
+            'title_audio_url' => Tts::getOrGenerate(
+                TtsAudioContext::make($level, 'title_audio_url', $locale)
+            ),
             'image_url' => $level->image_url,
             'text' => $level->text,
             'text_audio_url' => Tts::getOrGenerate(

--- a/laravel/app/Games/TrueFalseText/Models/TrueFalseTextLevel.php
+++ b/laravel/app/Games/TrueFalseText/Models/TrueFalseTextLevel.php
@@ -22,16 +22,18 @@ class TrueFalseTextLevel extends Level implements TtsAudioInterface
         'image_url',
         'text',
         'text_audio_url',
+        'title_audio_url',
     ];
 
     protected $attributes = [
         'title' => '{}',
         'text' => '{}',
         'text_audio_url' => '{}',
+        'title_audio_url' => '{}',
     ];
 
     /** @var array<int, string> */
-    public $translatable = ['title', 'text', 'text_audio_url'];
+    public $translatable = ['title', 'text', 'text_audio_url', 'title_audio_url'];
 
     public function statements(): HasMany
     {

--- a/laravel/database/migrations/2026_04_03_000000_add_title_audio_url_to_true_false_levels_tables.php
+++ b/laravel/database/migrations/2026_04_03_000000_add_title_audio_url_to_true_false_levels_tables.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('true_false_image_levels', function (Blueprint $table) {
+            $table->json('title_audio_url')->nullable()->after('title');
+        });
+
+        Schema::table('true_false_text_levels', function (Blueprint $table) {
+            $table->json('title_audio_url')->nullable()->after('title');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('true_false_image_levels', function (Blueprint $table) {
+            $table->dropColumn('title_audio_url');
+        });
+
+        Schema::table('true_false_text_levels', function (Blueprint $table) {
+            $table->dropColumn('title_audio_url');
+        });
+    }
+};

--- a/laravel/database/migrations/2026_04_03_000000_add_title_audio_url_to_true_false_levels_tables.php
+++ b/laravel/database/migrations/2026_04_03_000000_add_title_audio_url_to_true_false_levels_tables.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -18,6 +19,9 @@ return new class extends Migration
         Schema::table('true_false_text_levels', function (Blueprint $table) {
             $table->json('title_audio_url')->nullable()->after('title');
         });
+
+        DB::table('true_false_image_levels')->whereNull('title_audio_url')->update(['title_audio_url' => '{}']);
+        DB::table('true_false_text_levels')->whereNull('title_audio_url')->update(['title_audio_url' => '{}']);
     }
 
     /**

--- a/laravel/database/migrations/2026_04_03_000000_add_title_audio_url_to_true_false_levels_tables.php
+++ b/laravel/database/migrations/2026_04_03_000000_add_title_audio_url_to_true_false_levels_tables.php
@@ -12,6 +12,8 @@ return new class extends Migration
      */
     public function up(): void
     {
+        // Note: MySQL/MariaDB does not support transactional DDL — any Schema::table
+        // call causes an implicit commit and cannot be rolled back automatically.
         Schema::table('true_false_image_levels', function (Blueprint $table) {
             $table->json('title_audio_url')->nullable()->after('title');
         });

--- a/laravel/package.json
+++ b/laravel/package.json
@@ -5,7 +5,7 @@
         "build": "vite build"
     },
     "devDependencies": {
-        "axios": "^1.1.2",
+        "axios": "1.14.0",
         "laravel-vite-plugin": "^0.7.2",
         "vite": "^4.0.0"
     }

--- a/laravel/tests/Unit/Games/TrueFalseImage/Http/Resources/TrueFalseImageResourceTest.php
+++ b/laravel/tests/Unit/Games/TrueFalseImage/Http/Resources/TrueFalseImageResourceTest.php
@@ -10,7 +10,6 @@ use Tests\TestCase;
 
 class TrueFalseImageResourceTest extends TestCase
 {
-
     protected function setUp(): void
     {
         parent::setUp();

--- a/laravel/tests/Unit/Games/TrueFalseImage/Http/Resources/TrueFalseImageResourceTest.php
+++ b/laravel/tests/Unit/Games/TrueFalseImage/Http/Resources/TrueFalseImageResourceTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Unit\Games\TrueFalseImage\Http\Resources;
 
+use App\Games\TrueFalseImage\Http\Resources\TrueFalseImageLevelResource;
 use App\Games\TrueFalseImage\Http\Resources\TrueFalseImageStatementResource;
+use App\Games\TrueFalseImage\Models\TrueFalseImageLevel;
 use App\Games\TrueFalseImage\Models\TrueFalseImageStatement;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -32,5 +34,22 @@ class TrueFalseImageResourceTest extends TestCase
 
         // Audio SHOULD NOT fallback to English
         $this->assertNull($data['statement_audio_url']);
+    }
+
+    /** @test */
+    public function true_false_image_level_resource_disables_audio_fallback(): void
+    {
+        $level = new TrueFalseImageLevel;
+        $level->setTranslation('title', 'en', 'English Title');
+        $level->setTranslation('title_audio_url', 'en', 'en_title_audio.mp3');
+
+        $resource = new TrueFalseImageLevelResource($level);
+        $data = $resource->toArray(request());
+
+        // Text/Title SHOULD fallback to English
+        $this->assertEquals('English Title', $data['title']);
+
+        // Audio SHOULD NOT fallback to English
+        $this->assertNull($data['title_audio_url']);
     }
 }

--- a/laravel/tests/Unit/Games/TrueFalseImage/Http/Resources/TrueFalseImageResourceTest.php
+++ b/laravel/tests/Unit/Games/TrueFalseImage/Http/Resources/TrueFalseImageResourceTest.php
@@ -6,12 +6,10 @@ use App\Games\TrueFalseImage\Http\Resources\TrueFalseImageLevelResource;
 use App\Games\TrueFalseImage\Http\Resources\TrueFalseImageStatementResource;
 use App\Games\TrueFalseImage\Models\TrueFalseImageLevel;
 use App\Games\TrueFalseImage\Models\TrueFalseImageStatement;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class TrueFalseImageResourceTest extends TestCase
 {
-    use RefreshDatabase;
 
     protected function setUp(): void
     {

--- a/laravel/tests/Unit/Games/TrueFalseText/Http/Resources/TrueFalseTextResourceTest.php
+++ b/laravel/tests/Unit/Games/TrueFalseText/Http/Resources/TrueFalseTextResourceTest.php
@@ -10,7 +10,6 @@ use Tests\TestCase;
 
 class TrueFalseTextResourceTest extends TestCase
 {
-
     protected function setUp(): void
     {
         parent::setUp();

--- a/laravel/tests/Unit/Games/TrueFalseText/Http/Resources/TrueFalseTextResourceTest.php
+++ b/laravel/tests/Unit/Games/TrueFalseText/Http/Resources/TrueFalseTextResourceTest.php
@@ -6,12 +6,10 @@ use App\Games\TrueFalseText\Http\Resources\TrueFalseTextLevelResource;
 use App\Games\TrueFalseText\Http\Resources\TrueFalseTextStatementResource;
 use App\Games\TrueFalseText\Models\TrueFalseTextLevel;
 use App\Games\TrueFalseText\Models\TrueFalseTextStatement;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class TrueFalseTextResourceTest extends TestCase
 {
-    use RefreshDatabase;
 
     protected function setUp(): void
     {
@@ -20,7 +18,7 @@ class TrueFalseTextResourceTest extends TestCase
     }
 
     /** @test */
-    public function true_false_text_statement_resource_disables_audio_fallback()
+    public function true_false_text_statement_resource_disables_audio_fallback(): void
     {
         $statement = new TrueFalseTextStatement;
         $statement->setTranslation('statement', 'en', 'English Statement');
@@ -37,18 +35,20 @@ class TrueFalseTextResourceTest extends TestCase
     }
 
     /** @test */
-    public function true_false_text_level_resource_disables_audio_fallback()
+    public function true_false_text_level_resource_disables_audio_fallback(): void
     {
         $level = new TrueFalseTextLevel;
         $level->setTranslation('title', 'en', 'English Title');
+        $level->setTranslation('text', 'en', 'English Text');
         $level->setTranslation('title_audio_url', 'en', 'en_title_audio.mp3');
         $level->setTranslation('text_audio_url', 'en', 'en_text_audio.mp3');
 
         $resource = new TrueFalseTextLevelResource($level);
         $data = $resource->toArray(request());
 
-        // Text/Title SHOULD fallback
+        // Text/Title SHOULD fallback to English
         $this->assertEquals('English Title', $data['title']);
+        $this->assertEquals('English Text', $data['text']);
 
         // Audio SHOULD NOT fallback
         $this->assertNull($data['title_audio_url']);

--- a/laravel/tests/Unit/Games/TrueFalseText/Http/Resources/TrueFalseTextResourceTest.php
+++ b/laravel/tests/Unit/Games/TrueFalseText/Http/Resources/TrueFalseTextResourceTest.php
@@ -41,6 +41,7 @@ class TrueFalseTextResourceTest extends TestCase
     {
         $level = new TrueFalseTextLevel;
         $level->setTranslation('title', 'en', 'English Title');
+        $level->setTranslation('title_audio_url', 'en', 'en_title_audio.mp3');
         $level->setTranslation('text_audio_url', 'en', 'en_text_audio.mp3');
 
         $resource = new TrueFalseTextLevelResource($level);
@@ -50,6 +51,7 @@ class TrueFalseTextResourceTest extends TestCase
         $this->assertEquals('English Title', $data['title']);
 
         // Audio SHOULD NOT fallback
+        $this->assertNull($data['title_audio_url']);
         $this->assertNull($data['text_audio_url']);
     }
 }


### PR DESCRIPTION
- [x] Create migration adding title_audio_url (JSON, nullable) to true_false_image_levels and true_false_text_levels.
- [x] Update TrueFalseImageLevel model: implement TtsAudioInterface, use HasTtsAudio, update $fillable, $translatable, and $attributes.
- [x] Update TrueFalseTextLevel model: update $fillable, $translatable, and $attributes.
- [x] Update TrueFalseImageLevelResource: add title_audio_url using Tts::getOrGenerate logic and update OpenAPI annotations.
- [x] Update TrueFalseTextLevelResource: add title_audio_url using Tts::getOrGenerate logic and update OpenAPI annotations.