### PR TITLE
Implement secure password update endpointss-074

### DIFF
--- a/laravel/app/Http/Controllers/ProfilePasswordController.php
+++ b/laravel/app/Http/Controllers/ProfilePasswordController.php
@@ -3,12 +3,13 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\UpdatePasswordRequest;
+use App\Services\PasswordService;
 use Illuminate\Http\Response;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Hash;
 
 class ProfilePasswordController extends Controller
 {
+    public function __construct(private readonly PasswordService $passwordService) {}
+
     /**
      * Update the authenticated user's password.
      *
@@ -31,7 +32,7 @@ class ProfilePasswordController extends Controller
      *             required={"current_password", "new_password", "new_password_confirmation"},
      *
      *             @OA\Property(property="current_password", type="string", example="secret123"),
-     *             @OA\Property(property="new_password", type="string", minLength=6, example="newSecret456"),
+     *             @OA\Property(property="new_password", type="string", minLength=8, example="newSecret456"),
      *             @OA\Property(property="new_password_confirmation", type="string", example="newSecret456")
      *         )
      *     ),
@@ -55,17 +56,7 @@ class ProfilePasswordController extends Controller
         /** @var \App\Models\User $user */
         $user = $request->user();
 
-        $user->password = Hash::make($request->new_password);
-        $user->save();
-
-        /** @var \Laravel\Sanctum\PersonalAccessToken $currentToken */
-        $currentToken = $user->currentAccessToken();
-        $currentTokenId = $currentToken->id;
-        $user->tokens()->where('id', '!=', $currentTokenId)->delete();
-
-        DB::table('password_reset_tokens')
-            ->where('email', $user->email)
-            ->delete();
+        $this->passwordService->update($user, $request->new_password);
 
         return response()->noContent();
     }

--- a/laravel/app/Http/Controllers/ProfilePasswordController.php
+++ b/laravel/app/Http/Controllers/ProfilePasswordController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\UpdatePasswordRequest;
 use App\Services\PasswordService;
-use Illuminate\Http\Response;
+use Illuminate\Http\JsonResponse;
 
 class ProfilePasswordController extends Controller
 {
@@ -13,14 +13,15 @@ class ProfilePasswordController extends Controller
     /**
      * Update the authenticated user's password.
      *
-     * Validates the current password, hashes and saves the new one,
-     * revokes all other active Sanctum tokens (other sessions),
-     * and clears any pending password reset tokens.
+     * Validates the current password, hashes and saves the new one inside a
+     * single DB transaction that also revokes **all** existing Sanctum tokens
+     * and clears any pending password reset tokens. A fresh Bearer token is
+     * issued atomically and returned to the client so the session stays alive.
      *
      * @OA\Put(
      *     path="/api/profile/password",
      *     summary="Update authenticated user password",
-     *     description="Validates the current password, updates it with a new hash, invalidates all other active sessions, and clears pending password reset tokens.",
+     *     description="Validates the current password, updates it with a new hash, revokes all existing tokens, clears pending password reset tokens, and returns a fresh Bearer token.",
      *     operationId="updateUserPassword",
      *     tags={"Profile"},
      *     security={{"sanctum": {}}},
@@ -38,9 +39,16 @@ class ProfilePasswordController extends Controller
      *     ),
      *
      *     @OA\Response(
-     *         response=204,
-     *         description="Password updated successfully"
+     *         response=200,
+     *         description="Password updated — fresh token issued",
+     *
+     *         @OA\JsonContent(
+     *
+     *             @OA\Property(property="access_token", type="string"),
+     *             @OA\Property(property="token_type", type="string", example="Bearer")
+     *         )
      *     ),
+     *
      *     @OA\Response(
      *         response=401,
      *         description="Unauthenticated"
@@ -51,13 +59,16 @@ class ProfilePasswordController extends Controller
      *     )
      * )
      */
-    public function update(UpdatePasswordRequest $request): Response
+    public function update(UpdatePasswordRequest $request): JsonResponse
     {
         /** @var \App\Models\User $user */
         $user = $request->user();
 
-        $this->passwordService->update($user, $request->new_password);
+        $token = $this->passwordService->update($user, $request->new_password);
 
-        return response()->noContent();
+        return new JsonResponse([
+            'access_token' => $token,
+            'token_type' => 'Bearer',
+        ]);
     }
 }

--- a/laravel/app/Http/Controllers/ProfilePasswordController.php
+++ b/laravel/app/Http/Controllers/ProfilePasswordController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\UpdatePasswordRequest;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+
+class ProfilePasswordController extends Controller
+{
+    /**
+     * Update the authenticated user's password.
+     *
+     * Validates the current password, hashes and saves the new one,
+     * revokes all other active Sanctum tokens (other sessions),
+     * and clears any pending password reset tokens.
+     *
+     * @OA\Put(
+     *     path="/api/profile/password",
+     *     summary="Update authenticated user password",
+     *     description="Validates the current password, updates it with a new hash, invalidates all other active sessions, and clears pending password reset tokens.",
+     *     operationId="updateUserPassword",
+     *     tags={"Profile"},
+     *     security={{"sanctum": {}}},
+     *
+     *     @OA\RequestBody(
+     *         required=true,
+     *
+     *         @OA\JsonContent(
+     *             required={"current_password", "new_password", "new_password_confirmation"},
+     *
+     *             @OA\Property(property="current_password", type="string", example="secret123"),
+     *             @OA\Property(property="new_password", type="string", minLength=6, example="newSecret456"),
+     *             @OA\Property(property="new_password_confirmation", type="string", example="newSecret456")
+     *         )
+     *     ),
+     *
+     *     @OA\Response(
+     *         response=204,
+     *         description="Password updated successfully"
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated"
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation failed"
+     *     )
+     * )
+     */
+    public function update(UpdatePasswordRequest $request): Response
+    {
+        /** @var \App\Models\User $user */
+        $user = $request->user();
+
+        $user->password = Hash::make($request->new_password);
+        $user->save();
+
+        /** @var \Laravel\Sanctum\PersonalAccessToken $currentToken */
+        $currentToken = $user->currentAccessToken();
+        $currentTokenId = $currentToken->id;
+        $user->tokens()->where('id', '!=', $currentTokenId)->delete();
+
+        DB::table('password_reset_tokens')
+            ->where('email', $user->email)
+            ->delete();
+
+        return response()->noContent();
+    }
+}

--- a/laravel/app/Http/Middleware/TrimStrings.php
+++ b/laravel/app/Http/Middleware/TrimStrings.php
@@ -15,5 +15,7 @@ class TrimStrings extends Middleware
         'current_password',
         'password',
         'password_confirmation',
+        'new_password',
+        'new_password_confirmation',
     ];
 }

--- a/laravel/app/Http/Requests/RegisterRequest.php
+++ b/laravel/app/Http/Requests/RegisterRequest.php
@@ -5,6 +5,7 @@ namespace App\Http\Requests;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Validation\Rules\Password;
 
 /**
  * @property string $name
@@ -31,7 +32,7 @@ class RegisterRequest extends FormRequest
         return [
             'name' => 'required|string|max:255',
             'email' => 'required|string|email|unique:users',
-            'password' => 'required|string|min:6|confirmed',
+            'password' => ['required', 'confirmed', Password::min(8)->mixedCase()->numbers()],
         ];
     }
 

--- a/laravel/app/Http/Requests/RegisterRequest.php
+++ b/laravel/app/Http/Requests/RegisterRequest.php
@@ -32,7 +32,7 @@ class RegisterRequest extends FormRequest
         return [
             'name' => 'required|string|max:255',
             'email' => 'required|string|email|unique:users',
-            'password' => ['required', 'confirmed', Password::min(8)->mixedCase()->numbers()],
+            'password' => ['required', 'string', 'confirmed', Password::min(8)->mixedCase()->numbers()],
         ];
     }
 

--- a/laravel/app/Http/Requests/RegisterRequest.php
+++ b/laravel/app/Http/Requests/RegisterRequest.php
@@ -48,7 +48,7 @@ class RegisterRequest extends FormRequest
     protected function failedValidation(Validator $validator): void
     {
         throw new HttpResponseException(response()->json([
-            'message' => 'Validation failed',
+            'message' => __('validation.failed_message'),
             'errors' => $validator->errors(),
         ], 422));
     }

--- a/laravel/app/Http/Requests/UpdatePasswordRequest.php
+++ b/laravel/app/Http/Requests/UpdatePasswordRequest.php
@@ -5,6 +5,7 @@ namespace App\Http\Requests;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Validation\Rules\Password;
 
 /**
  * @property string $current_password
@@ -17,7 +18,7 @@ class UpdatePasswordRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return (bool) $this->user();
+        return true;
     }
 
     /**
@@ -29,18 +30,15 @@ class UpdatePasswordRequest extends FormRequest
     {
         return [
             'current_password' => ['required', 'current_password'],
-            'new_password' => ['required', 'string', 'min:6', 'confirmed'],
+            'new_password' => ['required', 'confirmed', Password::min(8)->mixedCase()->numbers()],
         ];
     }
 
     /**
      * Handle a failed validation attempt.
      *
-     * @param  \Illuminate\Contracts\Validation\Validator  $validator
-     *                                                                 The validator instance containing the failed validation rules.
      *
      * @throws \Illuminate\Http\Exceptions\HttpResponseException
-     *                                                           Thrown to immediately return a JSON response with validation errors and a 422 status code.
      */
     protected function failedValidation(Validator $validator): void
     {

--- a/laravel/app/Http/Requests/UpdatePasswordRequest.php
+++ b/laravel/app/Http/Requests/UpdatePasswordRequest.php
@@ -43,7 +43,7 @@ class UpdatePasswordRequest extends FormRequest
     protected function failedValidation(Validator $validator): void
     {
         throw new HttpResponseException(response()->json([
-            'message' => 'Validation failed',
+            'message' => __('validation.failed_message'),
             'errors' => $validator->errors(),
         ], 422));
     }

--- a/laravel/app/Http/Requests/UpdatePasswordRequest.php
+++ b/laravel/app/Http/Requests/UpdatePasswordRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+/**
+ * @property string $current_password
+ * @property string $new_password
+ */
+class UpdatePasswordRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return (bool) $this->user();
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'current_password' => ['required', 'current_password'],
+            'new_password' => ['required', 'string', 'min:6', 'confirmed'],
+        ];
+    }
+
+    /**
+     * Handle a failed validation attempt.
+     *
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     *                                                                 The validator instance containing the failed validation rules.
+     *
+     * @throws \Illuminate\Http\Exceptions\HttpResponseException
+     *                                                           Thrown to immediately return a JSON response with validation errors and a 422 status code.
+     */
+    protected function failedValidation(Validator $validator): void
+    {
+        throw new HttpResponseException(response()->json([
+            'message' => 'Validation failed',
+            'errors' => $validator->errors(),
+        ], 422));
+    }
+}

--- a/laravel/app/Http/Requests/UpdatePasswordRequest.php
+++ b/laravel/app/Http/Requests/UpdatePasswordRequest.php
@@ -29,8 +29,8 @@ class UpdatePasswordRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'current_password' => ['required', 'current_password'],
-            'new_password' => ['required', 'confirmed', Password::min(8)->mixedCase()->numbers()],
+            'current_password' => ['required', 'string', 'current_password'],
+            'new_password' => ['required', 'string', 'confirmed', Password::min(8)->mixedCase()->numbers()],
         ];
     }
 

--- a/laravel/app/Services/PasswordService.php
+++ b/laravel/app/Services/PasswordService.php
@@ -5,23 +5,29 @@ namespace App\Services;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
-use Laravel\Sanctum\PersonalAccessToken;
 
 class PasswordService
 {
-    public function update(User $user, string $newPassword): void
+    /**
+     * Update the user's password, revoke all existing tokens, and issue a new one.
+     *
+     * The entire operation runs in a single DB transaction: if any step fails,
+     * the password change is rolled back, guaranteeing a consistent state.
+     *
+     * @return string The new plain-text Bearer token.
+     */
+    public function update(User $user, string $newPassword): string
     {
-        DB::transaction(function () use ($user, $newPassword) {
+        return DB::transaction(function () use ($user, $newPassword) {
             $user->update(['password' => Hash::make($newPassword)]);
-
-            $currentToken = $user->currentAccessToken();
-            if ($currentToken instanceof PersonalAccessToken) {
-                $user->tokens()->where('id', '!=', $currentToken->id)->delete();
-            }
 
             DB::table('password_reset_tokens')
                 ->where('email', $user->email)
                 ->delete();
+
+            $user->tokens()->delete();
+
+            return $user->createToken('auth_token')->plainTextToken;
         });
     }
 }

--- a/laravel/app/Services/PasswordService.php
+++ b/laravel/app/Services/PasswordService.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\PersonalAccessToken;
+
+class PasswordService
+{
+    public function update(User $user, string $newPassword): void
+    {
+        DB::transaction(function () use ($user, $newPassword) {
+            $user->update(['password' => Hash::make($newPassword)]);
+
+            $currentToken = $user->currentAccessToken();
+            if ($currentToken instanceof PersonalAccessToken) {
+                $user->tokens()->where('id', '!=', $currentToken->id)->delete();
+            }
+
+            DB::table('password_reset_tokens')
+                ->where('email', $user->email)
+                ->delete();
+        });
+    }
+}

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\AuthController;
 use App\Http\Controllers\GameController;
 use App\Http\Controllers\LevelController;
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\ProfilePasswordController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -24,6 +25,7 @@ Route::middleware('auth:sanctum')->post('auth/logout', [AuthController::class, '
 
 Route::middleware('auth:sanctum')->group(function () {
     Route::get('profile', [ProfileController::class, 'show'])->name('profile.show');
+    Route::put('profile/password', [ProfilePasswordController::class, 'update'])->name('profile.password.update');
 
     Route::apiResource('games', GameController::class)->only(['index', 'show']);
 

--- a/laravel/tests/Feature/AuthControllerTest.php
+++ b/laravel/tests/Feature/AuthControllerTest.php
@@ -25,8 +25,8 @@ class AuthControllerTest extends TestCase
         $response = $this->withMiddleware()->postJson('/api/auth/register', [
             'name' => 'Test User',
             'email' => 'test@example.com',
-            'password' => 'password123',
-            'password_confirmation' => 'password123',
+            'password' => 'Password123!',
+            'password_confirmation' => 'Password123!',
         ]);
 
         $response->assertCreated();
@@ -38,12 +38,12 @@ class AuthControllerTest extends TestCase
     {
         $user = \App\Models\User::factory()->create([
             'email' => 'login@example.com',
-            'password' => bcrypt('password123'),
+            'password' => bcrypt('Password123!'),
         ]);
 
         $response = $this->postJson('/api/auth/login', [
             'email' => 'login@example.com',
-            'password' => 'password123',
+            'password' => 'Password123!',
         ]);
 
         $response->assertOk();
@@ -55,7 +55,7 @@ class AuthControllerTest extends TestCase
     {
         $user = \App\Models\User::factory()->create([
             'email' => 'wrong@example.com',
-            'password' => bcrypt('password123'),
+            'password' => bcrypt('Password123!'),
         ]);
 
         $response = $this->postJson('/api/auth/login', [

--- a/laravel/tests/Feature/ProfilePasswordControllerTest.php
+++ b/laravel/tests/Feature/ProfilePasswordControllerTest.php
@@ -109,37 +109,87 @@ class ProfilePasswordControllerTest extends TestCase
     // ─── Successful update ────────────────────────────────────────────────────
 
     /** @test */
-    public function successful_update_returns_204_and_changes_password_in_db(): void
+    public function successful_update_returns_200_with_new_token(): void
     {
         $this->actingAs($this->user, 'sanctum')
             ->putJson(self::ENDPOINT, $this->validPayload())
-            ->assertNoContent();
+            ->assertOk()
+            ->assertJsonStructure(['access_token', 'token_type'])
+            ->assertJsonPath('token_type', 'Bearer');
+    }
+
+    /** @test */
+    public function successful_update_changes_password_in_db(): void
+    {
+        $this->actingAs($this->user, 'sanctum')
+            ->putJson(self::ENDPOINT, $this->validPayload())
+            ->assertOk();
 
         $this->assertTrue(Hash::check(self::NEW_PASSWORD, $this->user->fresh()->password));
     }
 
     /** @test */
-    public function successful_update_revokes_other_tokens_but_keeps_current_token(): void
+    public function successful_update_revokes_all_existing_tokens_and_issues_a_fresh_one(): void
     {
-        $currentToken = $this->user->createToken('current-device');
-        $otherToken = $this->user->createToken('other-device');
+        $oldToken1 = $this->user->createToken('device-1');
+        $oldToken2 = $this->user->createToken('device-2');
 
-        $this->withToken($currentToken->plainTextToken)
+        $response = $this->withToken($oldToken1->plainTextToken)
             ->putJson(self::ENDPOINT, $this->validPayload())
-            ->assertNoContent();
-
-        $this->assertDatabaseHas('personal_access_tokens', [
-            'id' => $currentToken->accessToken->id,
-        ]);
-
-        $this->assertDatabaseMissing('personal_access_tokens', [
-            'id' => $otherToken->accessToken->id,
-        ]);
-
-        // Verify the current token remains usable after the password change.
-        $this->withToken($currentToken->plainTextToken)
-            ->getJson('/api/profile')
             ->assertOk();
+
+        // Both old tokens must be gone.
+        $this->assertDatabaseMissing('personal_access_tokens', ['id' => $oldToken1->accessToken->id]);
+        $this->assertDatabaseMissing('personal_access_tokens', ['id' => $oldToken2->accessToken->id]);
+
+        // Exactly one new token must exist for this user.
+        $this->assertDatabaseCount('personal_access_tokens', 1);
+
+        // The fresh token returned in the response must be the only remaining one.
+        $newPlainToken = $response->json('access_token');
+        $this->getJson('/api/profile', ['Authorization' => "Bearer {$newPlainToken}"])
+            ->assertOk();
+    }
+
+    /** @test */
+    public function old_bearer_token_is_invalidated_after_password_change(): void
+    {
+        $oldToken = $this->user->createToken('old-session');
+
+        $this->withToken($oldToken->plainTextToken)
+            ->putJson(self::ENDPOINT, $this->validPayload())
+            ->assertOk();
+
+        // Assert the token row is gone from the DB — Sanctum looks up the token
+        // on every request, so a deleted row means the token is permanently invalid.
+        $this->assertDatabaseMissing('personal_access_tokens', [
+            'id' => $oldToken->accessToken->id,
+        ]);
+    }
+
+    /**
+     * Covers the non-PAT path: actingAs() sets a TransientToken (not a PersonalAccessToken).
+     * All existing DB tokens must still be revoked regardless of how the request is authenticated.
+     *
+     * @test
+     */
+    public function session_authenticated_request_revokes_all_existing_tokens(): void
+    {
+        $existingToken1 = $this->user->createToken('device-1');
+        $existingToken2 = $this->user->createToken('device-2');
+
+        // actingAs() uses a TransientToken — simulates web/session guard or no PAT context.
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->putJson(self::ENDPOINT, $this->validPayload())
+            ->assertOk()
+            ->assertJsonStructure(['access_token', 'token_type']);
+
+        // All pre-existing tokens must be gone.
+        $this->assertDatabaseMissing('personal_access_tokens', ['id' => $existingToken1->accessToken->id]);
+        $this->assertDatabaseMissing('personal_access_tokens', ['id' => $existingToken2->accessToken->id]);
+
+        // Only the newly issued token remains.
+        $this->assertDatabaseCount('personal_access_tokens', 1);
     }
 
     /** @test */
@@ -153,7 +203,7 @@ class ProfilePasswordControllerTest extends TestCase
 
         $this->actingAs($this->user, 'sanctum')
             ->putJson(self::ENDPOINT, $this->validPayload())
-            ->assertNoContent();
+            ->assertOk();
 
         $this->assertDatabaseMissing('password_reset_tokens', [
             'email' => $this->user->email,

--- a/laravel/tests/Feature/ProfilePasswordControllerTest.php
+++ b/laravel/tests/Feature/ProfilePasswordControllerTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class ProfilePasswordControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const ENDPOINT = '/api/profile/password';
+
+    private const CURRENT_PASSWORD = 'OldPassword1';
+
+    private const NEW_PASSWORD = 'NewPassword1';
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create([
+            'password' => Hash::make(self::CURRENT_PASSWORD),
+        ]);
+    }
+
+    private function validPayload(array $overrides = []): array
+    {
+        return array_merge([
+            'current_password' => self::CURRENT_PASSWORD,
+            'new_password' => self::NEW_PASSWORD,
+            'new_password_confirmation' => self::NEW_PASSWORD,
+        ], $overrides);
+    }
+
+    // ─── Auth guard ───────────────────────────────────────────────────────────
+
+    /** @test */
+    public function unauthenticated_user_gets_401(): void
+    {
+        $this->putJson(self::ENDPOINT, [])->assertUnauthorized();
+    }
+
+    // ─── Validation ───────────────────────────────────────────────────────────
+
+    /** @test */
+    public function wrong_current_password_returns_422(): void
+    {
+        $this->actingAs($this->user, 'sanctum')
+            ->putJson(self::ENDPOINT, $this->validPayload([
+                'current_password' => 'WrongPassword1',
+            ]))
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['current_password']);
+    }
+
+    /** @test */
+    public function new_password_too_short_returns_422(): void
+    {
+        $this->actingAs($this->user, 'sanctum')
+            ->putJson(self::ENDPOINT, $this->validPayload([
+                'new_password' => 'Abc1',
+                'new_password_confirmation' => 'Abc1',
+            ]))
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['new_password']);
+    }
+
+    /** @test */
+    public function new_password_without_mixed_case_returns_422(): void
+    {
+        $this->actingAs($this->user, 'sanctum')
+            ->putJson(self::ENDPOINT, $this->validPayload([
+                'new_password' => 'newpassword1',
+                'new_password_confirmation' => 'newpassword1',
+            ]))
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['new_password']);
+    }
+
+    /** @test */
+    public function new_password_without_numbers_returns_422(): void
+    {
+        $this->actingAs($this->user, 'sanctum')
+            ->putJson(self::ENDPOINT, $this->validPayload([
+                'new_password' => 'NewPassword',
+                'new_password_confirmation' => 'NewPassword',
+            ]))
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['new_password']);
+    }
+
+    /** @test */
+    public function new_password_confirmation_mismatch_returns_422(): void
+    {
+        $this->actingAs($this->user, 'sanctum')
+            ->putJson(self::ENDPOINT, $this->validPayload([
+                'new_password_confirmation' => 'DifferentPassword1',
+            ]))
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['new_password']);
+    }
+
+    // ─── Successful update ────────────────────────────────────────────────────
+
+    /** @test */
+    public function successful_update_returns_204_and_changes_password_in_db(): void
+    {
+        $this->actingAs($this->user, 'sanctum')
+            ->putJson(self::ENDPOINT, $this->validPayload())
+            ->assertNoContent();
+
+        $this->assertTrue(Hash::check(self::NEW_PASSWORD, $this->user->fresh()->password));
+    }
+
+    /** @test */
+    public function successful_update_revokes_other_tokens_but_keeps_current_token(): void
+    {
+        $currentToken = $this->user->createToken('current-device');
+        $otherToken = $this->user->createToken('other-device');
+
+        $this->withToken($currentToken->plainTextToken)
+            ->putJson(self::ENDPOINT, $this->validPayload())
+            ->assertNoContent();
+
+        $this->assertDatabaseHas('personal_access_tokens', [
+            'id' => $currentToken->accessToken->id,
+        ]);
+
+        $this->assertDatabaseMissing('personal_access_tokens', [
+            'id' => $otherToken->accessToken->id,
+        ]);
+
+        // Verify the current token remains usable after the password change.
+        $this->withToken($currentToken->plainTextToken)
+            ->getJson('/api/profile')
+            ->assertOk();
+    }
+
+    /** @test */
+    public function successful_update_deletes_password_reset_tokens_for_user(): void
+    {
+        DB::table('password_reset_tokens')->insert([
+            'email' => $this->user->email,
+            'token' => 'some-reset-token',
+            'created_at' => now(),
+        ]);
+
+        $this->actingAs($this->user, 'sanctum')
+            ->putJson(self::ENDPOINT, $this->validPayload())
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('password_reset_tokens', [
+            'email' => $this->user->email,
+        ]);
+    }
+}


### PR DESCRIPTION
- [x] Register PUT /api/profile/password routed to ProfilePasswordController@update.
- [x] Create UpdatePasswordRequest. Add rules: current_password (using Laravel's native current_password validation rule), and new_password (with string, required, min-length, and logical confirmation rules like confirmed).
- [x] Implement the update logic. Hash the new_password securely (Hash::make()) and save the User model. Ensure the update resets any active password reset tokens if applicable.
- [x] Write Feature tests verifying that providing an invalid current_password returns a 422 HTTP code, and providing a valid one successfully updates the hash and returns an appropriate success state (e.g. 200/204).