### PR TITLE
Return 404 for non numeric path parameters ss-082

### DIFF
--- a/laravel/app/Http/Controllers/LevelController.php
+++ b/laravel/app/Http/Controllers/LevelController.php
@@ -130,11 +130,11 @@ class LevelController extends Controller
      *     )
      * )
      */
-    public function show(Game $game, int $levelId): JsonResponse
+    public function show(Game $game, int $level): JsonResponse
     {
         try {
             $service = $this->factory->for($game);
-            $level = $service->fetchLevel($levelId);
+            $level = $service->fetchLevel($level);
         } catch (TableMissingException $e) {
             return response()->json(['message' => $e->getMessage()], 404);
         } catch (InvalidArgumentException $e) {

--- a/laravel/app/Http/Controllers/LevelController.php
+++ b/laravel/app/Http/Controllers/LevelController.php
@@ -30,8 +30,6 @@ class LevelController extends Controller
     /**
      * List levels for a game.
      *
-     * @param Game $game
-     * @return JsonResponse
      *
      * @OA\Get(
      *     path="/api/games/{game}/levels",
@@ -87,9 +85,6 @@ class LevelController extends Controller
     /**
      * Get single level by id.
      *
-     * @param Game $game
-     * @param int $levelId
-     * @return JsonResponse
      *
      * @OA\Get(
      *     path="/api/games/{game}/levels/{level}",
@@ -158,8 +153,6 @@ class LevelController extends Controller
     /**
      * Check player answers for a level.
      *
-     * @param CheckAnswersRequest $request
-     * @return JsonResponse
      *
      * @OA\Post(
      *     path="/api/games/{game}/levels/{level}/check",

--- a/laravel/app/Http/Controllers/LevelController.php
+++ b/laravel/app/Http/Controllers/LevelController.php
@@ -28,7 +28,10 @@ class LevelController extends Controller
     ) {}
 
     /**
-     * List levels for a game
+     * List levels for a game.
+     *
+     * @param Game $game
+     * @return JsonResponse
      *
      * @OA\Get(
      *     path="/api/games/{game}/levels",
@@ -82,10 +85,14 @@ class LevelController extends Controller
     }
 
     /**
-     * Get single level by id
+     * Get single level by id.
+     *
+     * @param Game $game
+     * @param int $levelId
+     * @return JsonResponse
      *
      * @OA\Get(
-     *     path="/api/games/{game}/levels/{levelId}",
+     *     path="/api/games/{game}/levels/{level}",
      *     tags={"Levels"},
      *     summary="Get a level",
      *     description="Returns single level data for the specified game and level id. Returns a 404 response when the level or levels table is missing.",
@@ -100,7 +107,7 @@ class LevelController extends Controller
      *     ),
      *
      *     @OA\Parameter(
-     *         name="levelId",
+     *         name="level",
      *         in="path",
      *         description="Level id",
      *         required=true,
@@ -130,11 +137,11 @@ class LevelController extends Controller
      *     )
      * )
      */
-    public function show(Game $game, int $level): JsonResponse
+    public function show(Game $game, int $levelId): JsonResponse
     {
         try {
             $service = $this->factory->for($game);
-            $level = $service->fetchLevel($level);
+            $level = $service->fetchLevel($levelId);
         } catch (TableMissingException $e) {
             return response()->json(['message' => $e->getMessage()], 404);
         } catch (InvalidArgumentException $e) {
@@ -149,10 +156,13 @@ class LevelController extends Controller
     }
 
     /**
-     * Check player answers for a level
+     * Check player answers for a level.
+     *
+     * @param CheckAnswersRequest $request
+     * @return JsonResponse
      *
      * @OA\Post(
-     *     path="/api/games/{game}/levels/{levelId}/check",
+     *     path="/api/games/{game}/levels/{level}/check",
      *     tags={"Levels"},
      *     summary="Check player answers for a level",
      *     description="Validates submitted answers and returns whether each answer is correct. Returns validation errors (422) if the payload is invalid or statements don't belong to the specified level, and 404 if the game, level, or relevant table is not found.",
@@ -167,7 +177,7 @@ class LevelController extends Controller
      *     ),
      *
      *     @OA\Parameter(
-     *         name="levelId",
+     *         name="level",
      *         in="path",
      *         description="Level id",
      *         required=true,

--- a/laravel/app/Http/Requests/CheckAnswersRequest.php
+++ b/laravel/app/Http/Requests/CheckAnswersRequest.php
@@ -87,7 +87,7 @@ class CheckAnswersRequest extends FormRequest
         $this->merge([
             'user_id' => auth()->id(),
             'game' => $game,
-            'level_id' => $this->route('levelId'),
+            'level_id' => $this->route('level'),
         ]);
     }
 

--- a/laravel/public/docs/api-docs.json
+++ b/laravel/public/docs/api-docs.json
@@ -125,14 +125,14 @@
                 }
             }
         },
-        "/api/games/{game}/levels/{levelId}": {
+        "/api/games/{game}/levels/{level}": {
             "get": {
                 "tags": [
                     "Levels"
                 ],
                 "summary": "Get a level",
                 "description": "Returns single level data for the specified game and level id. Returns a 404 response when the level or levels table is missing.",
-                "operationId": "4ca0478b229d137747917ad7f59da69f",
+                "operationId": "7fdc660383a6c79d80b46fe46dfffb6e",
                 "parameters": [
                     {
                         "name": "game",
@@ -146,7 +146,7 @@
                         }
                     },
                     {
-                        "name": "levelId",
+                        "name": "level",
                         "in": "path",
                         "description": "Level id",
                         "required": true,
@@ -191,14 +191,14 @@
                 }
             }
         },
-        "/api/games/{game}/levels/{levelId}/check": {
+        "/api/games/{game}/levels/{level}/check": {
             "post": {
                 "tags": [
                     "Levels"
                 ],
                 "summary": "Check player answers for a level",
                 "description": "Validates submitted answers and returns whether each answer is correct. Returns validation errors (422) if the payload is invalid or statements don't belong to the specified level, and 404 if the game, level, or relevant table is not found.",
-                "operationId": "ea2a7e9a47d694b2be8ca370b8ac2722",
+                "operationId": "fec3cc50167f799271d0d3c1003ee102",
                 "parameters": [
                     {
                         "name": "game",
@@ -212,7 +212,7 @@
                         }
                     },
                     {
-                        "name": "levelId",
+                        "name": "level",
                         "in": "path",
                         "description": "Level id",
                         "required": true,
@@ -356,6 +356,78 @@
                     },
                     "401": {
                         "description": "Unauthenticated"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/profile/password": {
+            "put": {
+                "tags": [
+                    "Profile"
+                ],
+                "summary": "Update authenticated user password",
+                "description": "Validates the current password, updates it with a new hash, revokes all existing tokens, clears pending password reset tokens, and returns a fresh Bearer token.",
+                "operationId": "updateUserPassword",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "current_password",
+                                    "new_password",
+                                    "new_password_confirmation"
+                                ],
+                                "properties": {
+                                    "current_password": {
+                                        "type": "string",
+                                        "example": "secret123"
+                                    },
+                                    "new_password": {
+                                        "type": "string",
+                                        "minLength": 8,
+                                        "example": "newSecret456"
+                                    },
+                                    "new_password_confirmation": {
+                                        "type": "string",
+                                        "example": "newSecret456"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Password updated — fresh token issued",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "access_token": {
+                                            "type": "string"
+                                        },
+                                        "token_type": {
+                                            "type": "string",
+                                            "example": "Bearer"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthenticated"
+                    },
+                    "422": {
+                        "description": "Validation failed"
                     }
                 },
                 "security": [

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -27,12 +27,15 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('profile', [ProfileController::class, 'show'])->name('profile.show');
     Route::put('profile/password', [ProfilePasswordController::class, 'update'])->name('profile.password.update');
 
-    Route::apiResource('games', GameController::class)->only(['index', 'show']);
+    Route::apiResource('games', GameController::class)->only(['index', 'show'])
+        ->whereNumber('game');
 
     Route::apiResource('games.levels', LevelController::class)
-        ->only(['index', 'show']);
+        ->only(['index', 'show'])
+        ->whereNumber(['game', 'level']);
 
-    Route::post('games/{game}/levels/{levelId}/check', [LevelController::class, 'check'])
-        ->name('games.levels.check');
+    Route::post('games/{game}/levels/{level}/check', [LevelController::class, 'check'])
+        ->name('games.levels.check')
+        ->whereNumber(['game', 'level']);
 
 });

--- a/laravel/tests/Feature/GameControllerTest.php
+++ b/laravel/tests/Feature/GameControllerTest.php
@@ -21,7 +21,7 @@ class GameControllerTest extends TestCase
         $this->actingAs(User::factory()->create())
             ->getJson('/api/games')
             ->assertStatus(200)
-            ->assertJsonStructure([]);
+            ->assertJsonIsArray();
     }
 
     public function test_show_missing_game_returns_404(): void

--- a/laravel/tests/Feature/GameControllerTest.php
+++ b/laravel/tests/Feature/GameControllerTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GameControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_show_missing_game_returns_404(): void
+    {
+        $this->actingAs(User::factory()->create())
+            ->getJson('/api/games/99999')
+            ->assertStatus(404);
+    }
+
+    public function test_non_numeric_game_id_returns_404(): void
+    {
+        $this->actingAs(User::factory()->create())
+            ->getJson('/api/games/abc')
+            ->assertStatus(404);
+    }
+}

--- a/laravel/tests/Feature/GameControllerTest.php
+++ b/laravel/tests/Feature/GameControllerTest.php
@@ -10,17 +10,33 @@ class GameControllerTest extends TestCase
 {
     use RefreshDatabase;
 
+    public function test_unauthenticated_user_cannot_access_game_index_returns_401(): void
+    {
+        $this->getJson('/api/games')
+            ->assertStatus(401);
+    }
+
+    public function test_authenticated_user_can_access_game_index_returns_200(): void
+    {
+        $this->actingAs(User::factory()->create())
+            ->getJson('/api/games')
+            ->assertStatus(200)
+            ->assertJsonStructure([]);
+    }
+
     public function test_show_missing_game_returns_404(): void
     {
         $this->actingAs(User::factory()->create())
             ->getJson('/api/games/99999')
-            ->assertStatus(404);
+            ->assertStatus(404)
+            ->assertJsonStructure(['message']);
     }
 
     public function test_non_numeric_game_id_returns_404(): void
     {
         $this->actingAs(User::factory()->create())
             ->getJson('/api/games/abc')
-            ->assertStatus(404);
+            ->assertStatus(404)
+            ->assertJsonStructure(['message']);
     }
 }

--- a/laravel/tests/Feature/LevelControllerTest.php
+++ b/laravel/tests/Feature/LevelControllerTest.php
@@ -546,15 +546,17 @@ class LevelControllerTest extends TestCase
     public function test_non_numeric_level_id_on_show_returns_404(): void
     {
         $user = User::factory()->create();
+        $game = Game::factory()->create();
 
-        $this->actingAs($user)->getJson('/api/games/1/levels/abc')->assertStatus(404);
+        $this->actingAs($user)->getJson("/api/games/{$game->id}/levels/abc")->assertStatus(404);
     }
 
     public function test_non_numeric_level_id_on_check_returns_404(): void
     {
         $user = User::factory()->create();
+        $game = Game::factory()->create();
 
-        $this->actingAs($user)->postJson('/api/games/1/levels/abc/check', [
+        $this->actingAs($user)->postJson("/api/games/{$game->id}/levels/abc/check", [
             'answers' => [['statement_id' => 1, 'answer' => true]],
         ])->assertStatus(404);
     }

--- a/laravel/tests/Feature/LevelControllerTest.php
+++ b/laravel/tests/Feature/LevelControllerTest.php
@@ -543,6 +543,28 @@ class LevelControllerTest extends TestCase
         }
     }
 
+    public function test_non_numeric_level_id_returns_404(): void
+    {
+        $game = Game::factory()->create(['table_prefix' => 'true_false_image']);
+        $user = User::factory()->create();
+
+        $this->actingAs($user)->getJson("/api/games/{$game->id}/levels/abc")->assertStatus(404);
+        $this->actingAs($user)->postJson("/api/games/{$game->id}/levels/abc/check", [
+            'answers' => [['statement_id' => 1, 'answer' => true]],
+        ])->assertStatus(404);
+    }
+
+    public function test_non_numeric_game_id_returns_404_for_level_routes(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)->getJson('/api/games/abc/levels')->assertStatus(404);
+        $this->actingAs($user)->getJson('/api/games/abc/levels/1')->assertStatus(404);
+        $this->actingAs($user)->postJson('/api/games/abc/levels/1/check', [
+            'answers' => [['statement_id' => 1, 'answer' => true]],
+        ])->assertStatus(404);
+    }
+
     public function test_unauthenticated_user_cannot_access_game_routes(): void
     {
         $game = Game::factory()->create();

--- a/laravel/tests/Feature/LevelControllerTest.php
+++ b/laravel/tests/Feature/LevelControllerTest.php
@@ -543,13 +543,18 @@ class LevelControllerTest extends TestCase
         }
     }
 
-    public function test_non_numeric_level_id_returns_404(): void
+    public function test_non_numeric_level_id_on_show_returns_404(): void
     {
-        $game = Game::factory()->create(['table_prefix' => 'true_false_image']);
         $user = User::factory()->create();
 
-        $this->actingAs($user)->getJson("/api/games/{$game->id}/levels/abc")->assertStatus(404);
-        $this->actingAs($user)->postJson("/api/games/{$game->id}/levels/abc/check", [
+        $this->actingAs($user)->getJson('/api/games/1/levels/abc')->assertStatus(404);
+    }
+
+    public function test_non_numeric_level_id_on_check_returns_404(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)->postJson('/api/games/1/levels/abc/check', [
             'answers' => [['statement_id' => 1, 'answer' => true]],
         ])->assertStatus(404);
     }


### PR DESCRIPTION
- [x] Add whereNumber route constraint to {game} segments in api.php so non-numeric values return 404 instead of causing a DB error or coercion
- [x] Resolve {levelId} as string (or add whereNumber constraint) in LevelController::show / LevelController::check and return 404 when the value
is non-numeric, replacing the current int $levelId type hint that causes a 500 TypeError
- [x] Add feature tests for both cases verifying 404 is returned for non-numeric path parameters