### PR TITLE
Add ci workflow ss-086

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    labels:
+      - dependencies
+      - github-actions
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,18 @@ jobs:
           restore-keys: |
             composer-${{ runner.os }}-php8.2-
 
+      - name: Cache vendor directory
+        id: vendor-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: laravel/vendor
+          key: vendor-${{ runner.os }}-php8.2-${{ hashFiles('laravel/composer.lock') }}
+
       - name: Prepare .env
         run: cp .env.testing .env
 
       - name: Install Composer dependencies
+        if: steps.vendor-cache.outputs.cache-hit != 'true'
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
 
       - name: Run PHPUnit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,10 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Tests, static analysis, code style
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    defaults:
+      run:
+        working-directory: laravel
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP 8.2
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: mbstring, xml, ctype, json, bcmath, curl, fileinfo, openssl, pdo, pdo_sqlite, tokenizer, zip, gd, intl
+          coverage: none
+          tools: composer:v2
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        shell: bash
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Composer downloads
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: composer-${{ runner.os }}-php8.2-${{ hashFiles('laravel/composer.lock') }}
+          restore-keys: |
+            composer-${{ runner.os }}-php8.2-
+
+      - name: Prepare .env
+        run: cp .env.testing .env
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+
+      - name: Run PHPUnit tests
+        run: php artisan test --parallel
+
+      - name: Run PHPStan
+        run: ./vendor/bin/phpstan analyse --no-progress --memory-limit=1G
+
+      - name: Check code style (Pint)
+        run: ./vendor/bin/pint --test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,13 @@ jobs:
         if: steps.vendor-cache.outputs.cache-hit != 'true'
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
 
+      # On cache hit composer install is skipped, so its post-autoload-dump hook
+      # (which runs `artisan package:discover` and writes bootstrap/cache/packages.php)
+      # doesn't fire. Run it explicitly to keep the manifest in sync with vendor/.
+      - name: Refresh Laravel package manifest on vendor cache hit
+        if: steps.vendor-cache.outputs.cache-hit == 'true'
+        run: php artisan package:discover --ansi
+
       - name: Run PHPUnit tests
         run: php artisan test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
 
       - name: Run PHPUnit tests
-        run: php artisan test --parallel
+        run: php artisan test
 
       - name: Run PHPStan
         run: ./vendor/bin/phpstan analyse --no-progress --memory-limit=1G

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup PHP 8.2
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
           php-version: '8.2'
           extensions: mbstring, xml, ctype, json, bcmath, curl, fileinfo, openssl, pdo, pdo_sqlite, tokenizer, zip, gd, intl
@@ -39,7 +39,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
       - name: Cache Composer downloads
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: composer-${{ runner.os }}-php8.2-${{ hashFiles('laravel/composer.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,11 @@ jobs:
           path: laravel/vendor
           key: vendor-${{ runner.os }}-php8.2-${{ hashFiles('laravel/composer.lock') }}
 
-      - name: Prepare .env
+      # `.env` is required by artisan commands that boot the Laravel framework:
+      # composer's post-autoload-dump hook runs `artisan package:discover`, and
+      # Larastan boots the container for type inference during PHPStan analysis.
+      # The actual test suite reads env vars from phpunit.xml, not from .env.
+      - name: Prepare .env for ancillary artisan calls
         run: cp .env.testing .env
 
       - name: Install Composer dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 **/.env
 **/.env.*
 !.env.example
+!**/.env.example
+!**/.env.production.example
+!**/.env.testing
 .phpunit.result.cache
 
 # Docker

--- a/laravel/.env.testing
+++ b/laravel/.env.testing
@@ -1,3 +1,10 @@
+# This file is committed intentionally. It is used by CI and local `php artisan test`.
+# The APP_KEY below is a DUMMY value with no security significance: it encrypts only
+# in-memory SQLite data that is discarded after each test run. Its sole purpose is
+# test reproducibility (stable signed URLs, encrypted cookies, etc.).
+# DO NOT reuse this key in any other environment (local dev, staging, production).
+# Each real environment must generate its own key via `php artisan key:generate`.
+
 APP_ENV=testing
 APP_KEY=base64:uqaNxew2UWCVfxxWrsLtqY7Ce13L1SbZ4uIYFSr4N7Q=
 DB_CONNECTION=sqlite

--- a/laravel/.env.testing
+++ b/laravel/.env.testing
@@ -1,0 +1,7 @@
+APP_ENV=testing
+APP_KEY=base64:uqaNxew2UWCVfxxWrsLtqY7Ce13L1SbZ4uIYFSr4N7Q=
+DB_CONNECTION=sqlite
+DB_DATABASE=:memory:
+
+FRONTEND_URL=http://localhost:3001
+


### PR DESCRIPTION
 - [x] Create .github/workflows/ci.yml.
 - [x] Setup PHP 8.2 with extensions: `mbstring, xml, ctype, json, bcmath, curl, fileinfo, openssl, pdo, pdo_sqlite, tokenizer, zip, gd, intl`. Rationale: standard Laravel 10 framework requirem+ents + `pdo_sqlite` (tests use SQLite in-memory) + `gd`/`intl` (image processing + i18n locale handling). **Intentionally omitted:** `pdo_mysql` (CI tests don't touch MySQL — production Docker +file installs it separately for runtime), `redis`/phpredis (project uses pure-PHP `predis/predis`; tests use `QUEUE_CONNECTION=sync` + `CACHE_DRIVER=array` per `phpunit.xml`, so no Redis at al+l).
 - [x] Cache Composer dependencies via actions/cache@v4, key from laravel/composer.lock.
 - [x] Step: composer install --no-interaction --prefer-dist --optimize-autoloader.
 - [x] Step: php artisan test (uses SQLite in-memory per phpunit.xml).
 - [x] Step: ./vendor/bin/phpstan analyse --no-progress.
 - [x] Step: ./vendor/bin/pint --test (check-only, no auto-format).
 - [x] Configure trigger: on: { push: { branches: [main, develop] }, pull_request: { branches: [main, develop] } }.