### PR TITLE
Prepare docker-compose for Coolify deployment ss-087

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,7 +9,6 @@ services:
   laravel:
     build:
       target: prod         # Builds the 'prod' stage (no Xdebug, optimised OPcache)
-    restart: always
     env_file:
       - ./laravel/.env     # No bind-mount in prod — credentials must be injected via env_file
     # No bind-mount: code is baked into the image at build time via COPY in Dockerfile.
@@ -18,23 +17,11 @@ services:
   queue-worker:
     build:
       target: prod         # Optimised OPcache, no Xdebug
-    restart: always
     env_file:
       - ./laravel/.env
 
-  mysql:
-    restart: always
-    # No port exposure: only accessible inside the app-network
-
-  nginx:
-    restart: always
-    ports:
-      - "80:80"    # HTTP — publicly exposed
-      - "443:443"  # HTTPS — publicly exposed (requires SSL config in nginx)
-
-  redis:
-    restart: always
-    # No port exposure: only accessible inside the app-network
-
-  ukrainian-tts:
-    restart: always
+  # nginx, mysql, redis, ukrainian-tts — no prod-specific overrides needed.
+  # Base docker-compose.yml already provides:
+  #   - restart: unless-stopped (Coolify-friendly; honours intentional shutdowns)
+  #   - expose: <port> (internal only, no host port mapping)
+  # In Coolify deployment, Traefik routes ${APP_DOMAIN} → nginx:80 via Docker network.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,10 @@ services:
     build:
       context: ./laravel
       dockerfile: docker/Dockerfile
-    container_name: pp_laravel_app
     restart: unless-stopped
     working_dir: /var/www
+    expose:
+      - "9000"  # PHP-FPM, internal only (consumed by nginx via Docker DNS)
     volumes:
       - laravel_public:/var/www/public  # written by entrypoint.sh from public-src
       - ./laravel/storage:/var/www/storage
@@ -40,7 +41,6 @@ services:
     build:
       context: ./laravel
       dockerfile: docker/Dockerfile
-    container_name: pp_queue_worker
     restart: unless-stopped
     working_dir: /var/www
     user: "33:33"
@@ -62,8 +62,9 @@ services:
 
   mysql:
     image: mysql:8.0
-    container_name: pp_mysql_db
     restart: unless-stopped
+    expose:
+      - "3306"  # internal only (host port mapping is added by dev override)
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD?}
       MYSQL_DATABASE: ${MYSQL_DATABASE:-laravel}
@@ -82,8 +83,9 @@ services:
 
   nginx:
     image: nginx:1.27-alpine
-    container_name: pp_nginx_server
     restart: unless-stopped
+    expose:
+      - "80"  # consumed by Coolify Traefik in prod (and by host port mapping in dev override)
     volumes:
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
       - laravel_public:/var/www/public:ro  # populated by laravel entrypoint from image
@@ -95,8 +97,9 @@ services:
 
   redis:
     image: redis:7-alpine
-    container_name: pp_redis_cache
     restart: unless-stopped
+    expose:
+      - "6379"  # internal only (host port mapping is added by dev override)
     command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD?}
     volumes:
       - redis_data:/data
@@ -113,8 +116,9 @@ services:
     build:
       context: ./python-services/ukrainian-tts
       dockerfile: Dockerfile
-    container_name: pp_ukrainian_tts
     restart: unless-stopped
+    expose:
+      - "5001"
     environment:
       - TTS_MAX_TEXT_LENGTH=${TTS_MAX_TEXT_LENGTH:-2000}
       - TTS_CHUNK_SIZE=${TTS_CHUNK_SIZE:-200}

--- a/laravel/docker/entrypoint.sh
+++ b/laravel/docker/entrypoint.sh
@@ -26,7 +26,9 @@ if [ "${APP_ENV}" = "production" ]; then
   php artisan route:cache
   php artisan view:cache
   echo "[entrypoint] Running migrations..."
-  php artisan migrate --force
+  # --isolated prevents concurrent migrations on rolling restart (multiple containers
+  # acquire an advisory lock; only the first proceeds, others wait/no-op).
+  php artisan migrate --force --isolated
 fi
 
 exec "$@"

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -16,7 +16,7 @@ server {
     # PHP-FPM handling
     location ~ \.php$ {
         include fastcgi_params;
-        fastcgi_pass pp_laravel_app:9000;
+        fastcgi_pass laravel:9000;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param PATH_INFO $fastcgi_path_info;

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "description": "## Description",
   "main": "index.js",
   "scripts": {
-    "lint": "docker exec -i pp_laravel_app php vendor/bin/phpstan analyse app --memory-limit=512M",
-    "format": "docker exec -i pp_laravel_app php vendor/bin/pint",
+    "lint": "docker compose exec -T laravel php vendor/bin/phpstan analyse app --memory-limit=512M",
+    "format": "docker compose exec -T laravel php vendor/bin/pint",
     "prepare": "husky install",
     "quality": "npm run format && npm run lint && npm run test",
-    "test": "docker exec -i pp_laravel_app php artisan test",
-    "docs": "docker exec -i pp_laravel_app php artisan l5-swagger:generate",
-    "queue:restart": "docker exec -i pp_laravel_app php artisan queue:restart"
+    "test": "docker compose exec -T laravel php artisan test",
+    "docs": "docker compose exec -T laravel php artisan l5-swagger:generate",
+    "queue:restart": "docker compose exec -T laravel php artisan queue:restart"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
 - [x] Remove all container_name: directives (Coolify prefixes names automatically).
 - [x] Replace all ports: mappings with expose: directives:
 - [x] Add restart: unless-stopped to every service.
 - [x] Remove dev-local-network reference (Kokoro TTS is dev-only).
 - [x] Keep app-network or rely on Coolify's auto-network.
 - [x] Remove listen 443 ssl; block and ssl_certificate* directives.
 - [x] Keep only listen 80;.
 - [x] Change fastcgi_pass pp_laravel_app:9000; → fastcgi_pass laravel:9000;.
 - [x] Verify static asset caching and gzip blocks remain intact.
 - [x] Audit for hardcoded pp_* references.
 - [x] Add --isolated flag to php artisan migrate --force (prevents concurrent migration on rolling restart).