### PR TITLE
Build prod image to GHCR + auto-deploy via Coolify webhook ss-099

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,66 @@ jobs:
 
       - name: Check code style (Pint)
         run: ./vendor/bin/pint --test
+
+  build-push:
+    name: Build & push image to GHCR
+    needs: test
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata (tags + labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/roman-prv/smartsprouts-backend
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=sha-,format=short
+
+      - name: Build and push prod image
+        uses: docker/build-push-action@v6
+        with:
+          context: laravel
+          file: laravel/docker/Dockerfile
+          target: prod
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: Trigger Coolify deploy
+    needs: build-push
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Call Coolify deployment webhook
+        env:
+          COOLIFY_WEBHOOK_URL: ${{ secrets.COOLIFY_WEBHOOK_URL }}
+          COOLIFY_WEBHOOK_TOKEN: ${{ secrets.COOLIFY_WEBHOOK_TOKEN }}
+        run: |
+          curl --fail-with-body --silent --show-error \
+            -X POST \
+            -H "Authorization: Bearer $COOLIFY_WEBHOOK_TOKEN" \
+            "$COOLIFY_WEBHOOK_URL"

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -6,33 +6,39 @@
 
 services:
   laravel:
+    image: smartsprouts-backend:dev
     build:
-      target: dev          # Builds the 'dev' stage (includes Xdebug)
+      context: ./laravel
+      dockerfile: docker/Dockerfile
+      target: dev
     environment:
       APP_ENV: local
       APP_DEBUG: true
     volumes:
-      - ./laravel:/var/www                      # Hot-reload: source code from host
-      - vendor_data:/var/www/vendor             # Preserve vendor across rebuilds
-      - ./laravel/public:/var/www/public        # Override named volume → bind-mount for dev hot-reload (mirrors nginx override)
-      - ./laravel/storage:/var/www/storage      # Override named volume → bind-mount for dev (logs visible on host)
+      - ./laravel:/var/www
+      - vendor_data:/var/www/vendor
+      - ./laravel/public:/var/www/public
+      - ./laravel/storage:/var/www/storage
     extra_hosts:
-      - "host.docker.internal:host-gateway"     # Required for Xdebug client_host
+      - "host.docker.internal:host-gateway"
     networks:
       - app-network
-      - dev-local-network                       # Connects to Kokoro TTS and other local dev services
+      - dev-local-network
 
   queue-worker:
+    image: smartsprouts-backend:dev
     build:
+      context: ./laravel
+      dockerfile: docker/Dockerfile
       target: dev
     env_file:
-      - ./laravel/.env  # dev only — prod injects vars via Coolify
+      - ./laravel/.env
     volumes:
       - ./laravel:/var/www
       - vendor_data:/var/www/vendor
-      - ./laravel/storage:/var/www/storage      # Override named volume → bind-mount for dev
+      - ./laravel/storage:/var/www/storage
     extra_hosts:
-      - "host.docker.internal:host-gateway"     # Required for Xdebug client_host
+      - "host.docker.internal:host-gateway"
     networks:
       - app-network
       - dev-local-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,16 +14,14 @@
 
 services:
   laravel:
-    build:
-      context: ./laravel
-      dockerfile: docker/Dockerfile
+    image: ghcr.io/roman-prv/smartsprouts-backend:latest
     restart: unless-stopped
     working_dir: /var/www
     expose:
-      - "9000"  # PHP-FPM, internal only (consumed by nginx via Docker DNS)
+      - "9000"
     volumes:
-      - laravel_public:/var/www/public    # written by entrypoint.sh from public-src
-      - laravel_storage:/var/www/storage  # named volume in prod; bind-mounted in dev (override)
+      - laravel_public:/var/www/public
+      - laravel_storage:/var/www/storage
     networks:
       - app-network
     depends_on:
@@ -39,9 +37,7 @@ services:
       start_period: 30s
 
   queue-worker:
-    build:
-      context: ./laravel
-      dockerfile: docker/Dockerfile
+    image: ghcr.io/roman-prv/smartsprouts-backend:latest
     restart: unless-stopped
     working_dir: /var/www
     user: "33:33"


### PR DESCRIPTION
 - [x] Base `docker-compose.yml`: `laravel` and `queue-worker` switched from `build:` to `image: ghcr.io/...:latest`. Coolify now pulls the prebuilt image instead of building on the server.
 - [x] Dev `docker-compose.override.yml(.example)`: added full `build:` spec back for those services with a dev-only image tag (`smartsprouts-backend:dev`), so local `docker compose up` still builds from source.