### PR TITLE
feat(db): bind MySQL to host loopback for SSH-tunneled admin access ss-112

### DIFF
--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -43,9 +43,8 @@ services:
       - app-network
       - dev-local-network
 
-  mysql:
-    ports:
-      - "127.0.0.1:3306:3306"  # Expose to host for local DB clients (TablePlus, DBeaver)
+  # mysql host port binding (127.0.0.1:3306:3306) is now defined in base
+  # docker-compose.yml — no need to duplicate here.
 
   nginx:
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,9 @@ services:
     image: mysql:8.0
     restart: unless-stopped
     expose:
-      - "3306"  # internal only (host port mapping is added by dev override)
+      - "3306"  # internal to docker network (for laravel container)
+    ports:
+      - "127.0.0.1:3306:3306"  # host loopback only — reachable via SSH tunnel, NEVER publicly
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD?}
       MYSQL_DATABASE: ${MYSQL_DATABASE:-laravel}


### PR DESCRIPTION
 - [x] Compose (prod): In docker-compose.yml, add ports: ["127.0.0.1:3306:3306"] to the mysql service block (alongside the existing expose: ["3306"]).
 - [x] Compose (dev template): In docker-compose.override.yml.example, remove the now-redundant mysql.ports block; replace with a comment noting the binding now lives in base.
 - [x] Dev migration: Locally, remove the duplicate mysql.ports block from your gitignored docker-compose.override.yml (otherwise docker compose up may error with "port already allocated").