### PR TITLE
 feat(admin): admin auth + dispatcher-based level CRUD ss-122

### DIFF
--- a/laravel/app/Contracts/LevelAdminServiceInterface.php
+++ b/laravel/app/Contracts/LevelAdminServiceInterface.php
@@ -18,11 +18,17 @@ interface LevelAdminServiceInterface
     public function list(): Collection;
 
     /**
+     * Image is required on create — enforced by the type, not by a runtime
+     * check in implementations.
+     *
      * @param  array<string, mixed>  $data
      */
-    public function create(array $data, ?UploadedFile $image): Level;
+    public function create(array $data, UploadedFile $image): Level;
 
     /**
+     * Image is optional on update — when null, the existing image is left
+     * untouched. When provided, implementations replace it.
+     *
      * @param  array<string, mixed>  $data
      */
     public function update(int $levelId, array $data, ?UploadedFile $image): Level;

--- a/laravel/app/Contracts/LevelAdminServiceInterface.php
+++ b/laravel/app/Contracts/LevelAdminServiceInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Contracts;
+
+use App\Models\Level;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\UploadedFile;
+
+/**
+ * Per-game admin operations on the game's levels (title, image, etc.).
+ * Resolved by table_prefix via LevelAdminServiceFactory; one implementation per game.
+ */
+interface LevelAdminServiceInterface
+{
+    /**
+     * @return Collection<int, Level>
+     */
+    public function list(): Collection;
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function create(array $data, ?UploadedFile $image): Level;
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function update(int $levelId, array $data, ?UploadedFile $image): Level;
+
+    public function delete(int $levelId): void;
+}

--- a/laravel/app/Contracts/TranslatableLevelInterface.php
+++ b/laravel/app/Contracts/TranslatableLevelInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Contracts;
+
+/**
+ * Marks a Level subclass whose admin-editable text fields are stored as
+ * Spatie translations. Implementations satisfy this contract automatically
+ * by using Spatie\Translatable\HasTranslations.
+ */
+interface TranslatableLevelInterface
+{
+    /**
+     * @return array<string, string>
+     */
+    public function getTranslations(string $attribute): array;
+}

--- a/laravel/app/Games/FindTheWrong/Models/FindTheWrongLevel.php
+++ b/laravel/app/Games/FindTheWrong/Models/FindTheWrongLevel.php
@@ -2,13 +2,14 @@
 
 namespace App\Games\FindTheWrong\Models;
 
+use App\Contracts\TranslatableLevelInterface;
 use App\Contracts\TtsAudioInterface;
 use App\Models\Level;
 use App\Traits\HasTtsAudio;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Spatie\Translatable\HasTranslations;
 
-class FindTheWrongLevel extends Level implements TtsAudioInterface
+class FindTheWrongLevel extends Level implements TranslatableLevelInterface, TtsAudioInterface
 {
     use HasTranslations;
     use HasTtsAudio;

--- a/laravel/app/Games/FindTheWrong/Models/FindTheWrongLevel.php
+++ b/laravel/app/Games/FindTheWrong/Models/FindTheWrongLevel.php
@@ -13,6 +13,8 @@ class FindTheWrongLevel extends Level implements TtsAudioInterface
     use HasTranslations;
     use HasTtsAudio;
 
+    public const STORAGE_ROOT = 'games/find-the-wrong/levels';
+
     protected $table = 'find_the_wrong_levels';
 
     protected $fillable = [
@@ -35,5 +37,14 @@ class FindTheWrongLevel extends Level implements TtsAudioInterface
     public function items(): HasMany
     {
         return $this->hasMany(FindTheWrongItem::class, 'level_id')->orderBy('id');
+    }
+
+    /**
+     * Directory under the configured upload disk where all of this level's
+     * content lives (cover image, TTS audio for title, item assets, etc.).
+     */
+    public function storageDirectory(): string
+    {
+        return self::STORAGE_ROOT.'/'.$this->id;
     }
 }

--- a/laravel/app/Games/FindTheWrong/Services/Admin/FindTheWrongLevelAdminService.php
+++ b/laravel/app/Games/FindTheWrong/Services/Admin/FindTheWrongLevelAdminService.php
@@ -8,7 +8,6 @@ use App\Helpers\ConfigHelper;
 use App\Models\Level;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Throwable;
@@ -34,8 +33,11 @@ class FindTheWrongLevelAdminService implements LevelAdminServiceInterface
     }
 
     /**
-     * Create a level and store its cover image. Runs inside a DB transaction so
-     * the row + image_url update happen atomically.
+     * Create a level and store its cover image. No DB transaction is used —
+     * file writes cannot participate in DB transactions, so wrapping them
+     * would only give a false sense of atomicity. If the upload or the
+     * follow-up UPDATE fails, the row remains with NULL image_url and the
+     * admin can fix it via PATCH or DELETE.
      *
      * @param  array<string, mixed>  $data
      *
@@ -47,20 +49,21 @@ class FindTheWrongLevelAdminService implements LevelAdminServiceInterface
             throw new \InvalidArgumentException('Image is required when creating a find_the_wrong level.');
         }
 
-        return DB::transaction(function () use ($data, $image): FindTheWrongLevel {
-            $level = FindTheWrongLevel::create([
-                'title' => $data['title'],
-            ]);
+        $level = FindTheWrongLevel::create([
+            'title' => $data['title'],
+        ]);
 
-            $level->update(['image_url' => $this->storeImage($image, $level)]);
+        $level->update(['image_url' => $this->storeImage($image, $level)]);
 
-            return $level->fresh() ?? $level;
-        });
+        return $level->fresh() ?? $level;
     }
 
     /**
-     * Update title and, optionally, replace the cover image. When no image is
-     * uploaded, the existing file is left in place untouched.
+     * Update title and, optionally, replace the cover image. The image write is
+     * append-only: the new file is uploaded before the DB save, and the old
+     * file is removed only after the save succeeds. This way an upload failure
+     * never destroys the existing image, and a DB failure leaves only an
+     * orphan file (not a broken image_url pointing at a deleted asset).
      *
      * @param  array<string, mixed>  $data
      */
@@ -68,6 +71,7 @@ class FindTheWrongLevelAdminService implements LevelAdminServiceInterface
     {
         /** @var FindTheWrongLevel $level */
         $level = FindTheWrongLevel::query()->findOrFail($levelId);
+        $oldImagePath = $level->getRawOriginal('image_url');
 
         $level->title = $data['title'];
 
@@ -76,6 +80,14 @@ class FindTheWrongLevelAdminService implements LevelAdminServiceInterface
         }
 
         $level->save();
+
+        if ($image !== null
+            && is_string($oldImagePath)
+            && $oldImagePath !== ''
+            && $oldImagePath !== $level->getRawOriginal('image_url')
+        ) {
+            $this->deleteSilently($oldImagePath, $level->id);
+        }
 
         return $level->fresh() ?? $level;
     }
@@ -102,16 +114,15 @@ class FindTheWrongLevelAdminService implements LevelAdminServiceInterface
     }
 
     /**
-     * Wipe the level's storage directory and store the new file as `image.{ext}`.
-     * Returns the path that should be written to `image_url`.
+     * Append-only: store the new file under the level's directory without
+     * touching any existing file. Returns the path to write into `image_url`.
+     * Old-file cleanup is the caller's responsibility, performed only after
+     * a successful DB save.
      */
     private function storeImage(UploadedFile $image, FindTheWrongLevel $level): string
     {
         $diskName = $this->diskName();
-        $disk = Storage::disk($diskName);
         $directory = $level->storageDirectory();
-
-        $disk->deleteDirectory($directory);
 
         $extension = $image->getClientOriginalExtension() ?: $image->guessExtension() ?: 'bin';
         $filename = "image.{$extension}";
@@ -119,6 +130,22 @@ class FindTheWrongLevelAdminService implements LevelAdminServiceInterface
         $path = $image->storeAs($directory, $filename, $diskName);
 
         return is_string($path) ? $path : "{$directory}/{$filename}";
+    }
+
+    /**
+     * Best-effort file delete; storage failures are logged, never thrown.
+     */
+    private function deleteSilently(string $path, int $levelId): void
+    {
+        try {
+            Storage::disk($this->diskName())->delete($path);
+        } catch (Throwable $e) {
+            Log::warning('Failed to clean replaced image after FindTheWrongLevel update', [
+                'level_id' => $levelId,
+                'path' => $path,
+                'error' => $e->getMessage(),
+            ]);
+        }
     }
 
     /**

--- a/laravel/app/Games/FindTheWrong/Services/Admin/FindTheWrongLevelAdminService.php
+++ b/laravel/app/Games/FindTheWrong/Services/Admin/FindTheWrongLevelAdminService.php
@@ -40,15 +40,9 @@ class FindTheWrongLevelAdminService implements LevelAdminServiceInterface
      * admin can fix it via PATCH or DELETE.
      *
      * @param  array<string, mixed>  $data
-     *
-     * @throws \InvalidArgumentException If no image is supplied.
      */
-    public function create(array $data, ?UploadedFile $image): Level
+    public function create(array $data, UploadedFile $image): Level
     {
-        if ($image === null) {
-            throw new \InvalidArgumentException('Image is required when creating a find_the_wrong level.');
-        }
-
         $level = FindTheWrongLevel::create([
             'title' => $data['title'],
         ]);

--- a/laravel/app/Games/FindTheWrong/Services/Admin/FindTheWrongLevelAdminService.php
+++ b/laravel/app/Games/FindTheWrong/Services/Admin/FindTheWrongLevelAdminService.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Games\FindTheWrong\Services\Admin;
+
+use App\Contracts\LevelAdminServiceInterface;
+use App\Games\FindTheWrong\Models\FindTheWrongLevel;
+use App\Helpers\ConfigHelper;
+use App\Models\Level;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Throwable;
+
+/**
+ * Admin-side CRUD for FindTheWrongLevel rows: persists DB changes and keeps
+ * each level's storage directory in sync (image upload, full cleanup on delete).
+ */
+class FindTheWrongLevelAdminService implements LevelAdminServiceInterface
+{
+    /**
+     * @return Collection<int, Level>
+     */
+    public function list(): Collection
+    {
+        /** @var Collection<int, Level> $levels */
+        $levels = FindTheWrongLevel::query()
+            ->withCount('items')
+            ->orderBy('id')
+            ->get();
+
+        return $levels;
+    }
+
+    /**
+     * Create a level and store its cover image. Runs inside a DB transaction so
+     * the row + image_url update happen atomically.
+     *
+     * @param  array<string, mixed>  $data
+     *
+     * @throws \InvalidArgumentException If no image is supplied.
+     */
+    public function create(array $data, ?UploadedFile $image): Level
+    {
+        if ($image === null) {
+            throw new \InvalidArgumentException('Image is required when creating a find_the_wrong level.');
+        }
+
+        return DB::transaction(function () use ($data, $image): FindTheWrongLevel {
+            $level = FindTheWrongLevel::create([
+                'title' => $data['title'],
+            ]);
+
+            $level->update(['image_url' => $this->storeImage($image, $level)]);
+
+            return $level->fresh() ?? $level;
+        });
+    }
+
+    /**
+     * Update title and, optionally, replace the cover image. When no image is
+     * uploaded, the existing file is left in place untouched.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function update(int $levelId, array $data, ?UploadedFile $image): Level
+    {
+        /** @var FindTheWrongLevel $level */
+        $level = FindTheWrongLevel::query()->findOrFail($levelId);
+
+        $level->title = $data['title'];
+
+        if ($image !== null) {
+            $level->image_url = $this->storeImage($image, $level);
+        }
+
+        $level->save();
+
+        return $level->fresh() ?? $level;
+    }
+
+    /**
+     * Delete the level (items cascade via FK) and best-effort wipe its storage
+     * directory. Storage failures are logged but never block the DB deletion.
+     */
+    public function delete(int $levelId): void
+    {
+        /** @var FindTheWrongLevel $level */
+        $level = FindTheWrongLevel::query()->findOrFail($levelId);
+        $directory = $level->storageDirectory();
+        $level->delete();
+
+        try {
+            Storage::disk($this->diskName())->deleteDirectory($directory);
+        } catch (Throwable $e) {
+            Log::warning('Failed to clean storage on FindTheWrongLevel delete', [
+                'level_id' => $levelId,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Wipe the level's storage directory and store the new file as `image.{ext}`.
+     * Returns the path that should be written to `image_url`.
+     */
+    private function storeImage(UploadedFile $image, FindTheWrongLevel $level): string
+    {
+        $diskName = $this->diskName();
+        $disk = Storage::disk($diskName);
+        $directory = $level->storageDirectory();
+
+        $disk->deleteDirectory($directory);
+
+        $extension = $image->getClientOriginalExtension() ?: $image->guessExtension() ?: 'bin';
+        $filename = "image.{$extension}";
+
+        $path = $image->storeAs($directory, $filename, $diskName);
+
+        return is_string($path) ? $path : "{$directory}/{$filename}";
+    }
+
+    /**
+     * Read the upload disk name from config (env-overridable: dev=public, prod=s3/R2).
+     */
+    private function diskName(): string
+    {
+        return ConfigHelper::getString('games.upload_disk', 'public');
+    }
+}

--- a/laravel/app/Games/TrueFalseImage/Models/TrueFalseImageLevel.php
+++ b/laravel/app/Games/TrueFalseImage/Models/TrueFalseImageLevel.php
@@ -2,6 +2,7 @@
 
 namespace App\Games\TrueFalseImage\Models;
 
+use App\Contracts\TranslatableLevelInterface;
 use App\Contracts\TtsAudioInterface;
 use App\Models\Level;
 use App\Traits\HasTtsAudio;
@@ -9,7 +10,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Spatie\Translatable\HasTranslations;
 
-class TrueFalseImageLevel extends Level implements TtsAudioInterface
+class TrueFalseImageLevel extends Level implements TranslatableLevelInterface, TtsAudioInterface
 {
     use HasFactory;
     use HasTranslations;

--- a/laravel/app/Games/TrueFalseText/Models/TrueFalseTextLevel.php
+++ b/laravel/app/Games/TrueFalseText/Models/TrueFalseTextLevel.php
@@ -2,6 +2,7 @@
 
 namespace App\Games\TrueFalseText\Models;
 
+use App\Contracts\TranslatableLevelInterface;
 use App\Contracts\TtsAudioInterface;
 use App\Models\Level;
 use App\Traits\HasTtsAudio;
@@ -9,7 +10,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Spatie\Translatable\HasTranslations;
 
-class TrueFalseTextLevel extends Level implements TtsAudioInterface
+class TrueFalseTextLevel extends Level implements TranslatableLevelInterface, TtsAudioInterface
 {
     use HasFactory;
     use HasTranslations;

--- a/laravel/app/Http/Controllers/Admin/LevelController.php
+++ b/laravel/app/Http/Controllers/Admin/LevelController.php
@@ -11,6 +11,7 @@ use App\Models\Game;
 use App\Services\LevelAdminServiceFactory;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Log;
 use InvalidArgumentException;
 
 /**
@@ -84,7 +85,9 @@ class LevelController extends Controller
     }
 
     /**
-     * Look up the admin service for this game; abort 400 if no implementation is registered.
+     * Look up the admin service for this game. Aborts 404 with a fixed message
+     * if no implementation is registered; the internal factory error is logged
+     * for debugging instead of leaking class names into the response.
      *
      * @throws \Symfony\Component\HttpKernel\Exception\HttpException
      */
@@ -93,7 +96,12 @@ class LevelController extends Controller
         try {
             return $this->factory->for($game);
         } catch (InvalidArgumentException $e) {
-            abort(400, $e->getMessage());
+            Log::warning('Admin level service not configured for game', [
+                'game_id' => $game->id,
+                'table_prefix' => $game->table_prefix,
+                'error' => $e->getMessage(),
+            ]);
+            abort(404, 'Admin operations are not available for this game.');
         }
     }
 }

--- a/laravel/app/Http/Controllers/Admin/LevelController.php
+++ b/laravel/app/Http/Controllers/Admin/LevelController.php
@@ -6,8 +6,8 @@ use App\Contracts\LevelAdminServiceInterface;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Admin\StoreLevelRequest;
 use App\Http\Requests\Admin\UpdateLevelRequest;
+use App\Http\Resources\Admin\LevelAdminResource;
 use App\Models\Game;
-use App\Models\Level;
 use App\Services\LevelAdminServiceFactory;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\UploadedFile;
@@ -27,9 +27,10 @@ class LevelController extends Controller
     public function index(Game $game): JsonResponse
     {
         $service = $this->resolveService($game);
-        $levels = $service->list();
 
-        return response()->json($levels->map(fn (Level $level): array => $this->serialize($level))->all());
+        return response()->json(
+            LevelAdminResource::collection($service->list())->resolve(request())
+        );
     }
 
     /**
@@ -46,7 +47,10 @@ class LevelController extends Controller
             'title' => $request->validated('title'),
         ], $image);
 
-        return response()->json($this->serialize($level), 201);
+        return response()->json(
+            LevelAdminResource::make($level)->resolve(request()),
+            201
+        );
     }
 
     /**
@@ -63,7 +67,9 @@ class LevelController extends Controller
             'title' => $request->validated('title'),
         ], $image);
 
-        return response()->json($this->serialize($updated));
+        return response()->json(
+            LevelAdminResource::make($updated)->resolve(request())
+        );
     }
 
     /**
@@ -89,26 +95,5 @@ class LevelController extends Controller
         } catch (InvalidArgumentException $e) {
             abort(400, $e->getMessage());
         }
-    }
-
-    /**
-     * Build the JSON shape for a single level. `items_count` is included only
-     * when the relation was counted via withCount() in the service.
-     *
-     * @return array<string, mixed>
-     */
-    private function serialize(Level $level): array
-    {
-        $payload = [
-            'id' => $level->id,
-            'title' => method_exists($level, 'getTranslations') ? $level->getTranslations('title') : $level->title,
-            'image_url' => $level->image_url,
-        ];
-
-        if (isset($level->items_count)) {
-            $payload['items_count'] = $level->items_count;
-        }
-
-        return $payload;
     }
 }

--- a/laravel/app/Http/Controllers/Admin/LevelController.php
+++ b/laravel/app/Http/Controllers/Admin/LevelController.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Contracts\LevelAdminServiceInterface;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\StoreLevelRequest;
+use App\Http\Requests\Admin\UpdateLevelRequest;
+use App\Models\Game;
+use App\Models\Level;
+use App\Services\LevelAdminServiceFactory;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\UploadedFile;
+use InvalidArgumentException;
+
+/**
+ * Generic admin endpoint for game levels. Dispatches per-game write operations
+ * to a LevelAdminServiceInterface implementation resolved via the factory.
+ */
+class LevelController extends Controller
+{
+    public function __construct(protected LevelAdminServiceFactory $factory) {}
+
+    /**
+     * List all levels for the given game (admin view, includes items_count).
+     */
+    public function index(Game $game): JsonResponse
+    {
+        $service = $this->resolveService($game);
+        $levels = $service->list();
+
+        return response()->json($levels->map(fn (Level $level): array => $this->serialize($level))->all());
+    }
+
+    /**
+     * Create a new level. Returns 201 with the persisted level payload.
+     */
+    public function store(StoreLevelRequest $request, Game $game): JsonResponse
+    {
+        $service = $this->resolveService($game);
+
+        /** @var UploadedFile $image */
+        $image = $request->file('image');
+
+        $level = $service->create([
+            'title' => $request->validated('title'),
+        ], $image);
+
+        return response()->json($this->serialize($level), 201);
+    }
+
+    /**
+     * Update a level's metadata; image is replaced only when a file is attached.
+     */
+    public function update(UpdateLevelRequest $request, Game $game, int $level): JsonResponse
+    {
+        $service = $this->resolveService($game);
+
+        /** @var UploadedFile|null $image */
+        $image = $request->file('image');
+
+        $updated = $service->update($level, [
+            'title' => $request->validated('title'),
+        ], $image);
+
+        return response()->json($this->serialize($updated));
+    }
+
+    /**
+     * Delete a level. Items cascade via FK; storage cleanup is best-effort.
+     */
+    public function destroy(Game $game, int $level): JsonResponse
+    {
+        $service = $this->resolveService($game);
+        $service->delete($level);
+
+        return response()->json(null, 204);
+    }
+
+    /**
+     * Look up the admin service for this game; abort 400 if no implementation is registered.
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
+     */
+    private function resolveService(Game $game): LevelAdminServiceInterface
+    {
+        try {
+            return $this->factory->for($game);
+        } catch (InvalidArgumentException $e) {
+            abort(400, $e->getMessage());
+        }
+    }
+
+    /**
+     * Build the JSON shape for a single level. `items_count` is included only
+     * when the relation was counted via withCount() in the service.
+     *
+     * @return array<string, mixed>
+     */
+    private function serialize(Level $level): array
+    {
+        $payload = [
+            'id' => $level->id,
+            'title' => method_exists($level, 'getTranslations') ? $level->getTranslations('title') : $level->title,
+            'image_url' => $level->image_url,
+        ];
+
+        if (isset($level->items_count)) {
+            $payload['items_count'] = $level->items_count;
+        }
+
+        return $payload;
+    }
+}

--- a/laravel/app/Http/Middleware/EnsureAdmin.php
+++ b/laravel/app/Http/Middleware/EnsureAdmin.php
@@ -8,8 +8,9 @@ use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * Block requests from non-admin users. Assumes the route is already gated by
- * an auth middleware — guests will be rejected before reaching this layer.
+ * Block requests from unauthenticated users (401) and from authenticated
+ * users without admin privileges (403). Typically paired with auth:sanctum
+ * upstream, but also produces correct HTTP codes when used standalone.
  */
 class EnsureAdmin
 {
@@ -20,7 +21,11 @@ class EnsureAdmin
     {
         $user = $request->user();
 
-        if (! $user instanceof User || ! $user->is_admin) {
+        if (! $user instanceof User) {
+            abort(Response::HTTP_UNAUTHORIZED, 'Authentication required.');
+        }
+
+        if (! $user->is_admin) {
             abort(Response::HTTP_FORBIDDEN, 'Admin privileges required.');
         }
 

--- a/laravel/app/Http/Middleware/EnsureAdmin.php
+++ b/laravel/app/Http/Middleware/EnsureAdmin.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\User;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Block requests from non-admin users. Assumes the route is already gated by
+ * an auth middleware — guests will be rejected before reaching this layer.
+ */
+class EnsureAdmin
+{
+    /**
+     * @param  \Closure(\Illuminate\Http\Request): \Symfony\Component\HttpFoundation\Response  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        if (! $user instanceof User || ! $user->is_admin) {
+            abort(Response::HTTP_FORBIDDEN, 'Admin privileges required.');
+        }
+
+        return $next($request);
+    }
+}

--- a/laravel/app/Http/Middleware/EnsureAdmin.php
+++ b/laravel/app/Http/Middleware/EnsureAdmin.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Response;
 class EnsureAdmin
 {
     /**
-     * @param  \Closure(\Illuminate\Http\Request): \Symfony\Component\HttpFoundation\Response  $next
+     * @param  Closure(Request): Response  $next
      */
     public function handle(Request $request, Closure $next): Response
     {

--- a/laravel/app/Http/Requests/Admin/StoreLevelRequest.php
+++ b/laravel/app/Http/Requests/Admin/StoreLevelRequest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+/**
+ * Validates an admin "create level" request for any game whose admin operations
+ * are dispatched via App\Http\Controllers\Admin\LevelController.
+ *
+ * @OA\Schema(
+ *     schema="Admin.StoreLevelRequest",
+ *     type="object",
+ *     title="Admin Store Level Request",
+ *     description="Multipart/form-data payload for creating a new game level.",
+ *     required={"title", "image"},
+ *
+ *     @OA\Property(
+ *         property="title",
+ *         type="object",
+ *         description="Localized level title. All three locales are required.",
+ *         required={"uk", "en", "es"},
+ *         @OA\Property(property="uk", type="string", maxLength=255, example="Кухня"),
+ *         @OA\Property(property="en", type="string", maxLength=255, example="Kitchen"),
+ *         @OA\Property(property="es", type="string", maxLength=255, example="Cocina")
+ *     ),
+ *     @OA\Property(
+ *         property="image",
+ *         type="string",
+ *         format="binary",
+ *         description="Cover image (jpeg/png/webp, max 5 MB)."
+ *     )
+ * )
+ */
+class StoreLevelRequest extends FormRequest
+{
+    /**
+     * Authorization is delegated to the route middleware (auth + EnsureAdmin).
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => 'required|array',
+            'title.uk' => 'required|string|max:255',
+            'title.en' => 'required|string|max:255',
+            'title.es' => 'required|string|max:255',
+            'image' => 'required|file|mimes:jpeg,png,webp|max:5120',
+        ];
+    }
+
+    /**
+     * Convert validation failures into a JSON 422 instead of the default redirect.
+     *
+     * @throws HttpResponseException
+     */
+    protected function failedValidation(Validator $validator): void
+    {
+        throw new HttpResponseException(response()->json([
+            'message' => __('validation.failed_message'),
+            'errors' => $validator->errors(),
+        ], 422));
+    }
+}

--- a/laravel/app/Http/Requests/Admin/StoreLevelRequest.php
+++ b/laravel/app/Http/Requests/Admin/StoreLevelRequest.php
@@ -2,9 +2,8 @@
 
 namespace App\Http\Requests\Admin;
 
-use Illuminate\Contracts\Validation\Validator;
+use App\Traits\RespondsWithJsonValidation;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Http\Exceptions\HttpResponseException;
 
 /**
  * Validates an admin "create level" request for any game whose admin operations
@@ -36,6 +35,8 @@ use Illuminate\Http\Exceptions\HttpResponseException;
  */
 class StoreLevelRequest extends FormRequest
 {
+    use RespondsWithJsonValidation;
+
     /**
      * Authorization is delegated to the route middleware (auth + EnsureAdmin).
      */
@@ -56,18 +57,5 @@ class StoreLevelRequest extends FormRequest
             'title.es' => 'required|string|max:255',
             'image' => 'required|file|mimes:jpeg,png,webp|max:5120',
         ];
-    }
-
-    /**
-     * Convert validation failures into a JSON 422 instead of the default redirect.
-     *
-     * @throws HttpResponseException
-     */
-    protected function failedValidation(Validator $validator): void
-    {
-        throw new HttpResponseException(response()->json([
-            'message' => __('validation.failed_message'),
-            'errors' => $validator->errors(),
-        ], 422));
     }
 }

--- a/laravel/app/Http/Requests/Admin/UpdateLevelRequest.php
+++ b/laravel/app/Http/Requests/Admin/UpdateLevelRequest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+/**
+ * Validates an admin "update level" request. Same shape as StoreLevelRequest
+ * except the image is optional — when absent, the existing image stays.
+ *
+ * @OA\Schema(
+ *     schema="Admin.UpdateLevelRequest",
+ *     type="object",
+ *     title="Admin Update Level Request",
+ *     description="Multipart/form-data payload for updating an existing game level. Send via POST with _method=PATCH so the file part survives Laravel's form-method spoofing.",
+ *     required={"title"},
+ *
+ *     @OA\Property(
+ *         property="title",
+ *         type="object",
+ *         description="Localized level title. All three locales are required.",
+ *         required={"uk", "en", "es"},
+ *         @OA\Property(property="uk", type="string", maxLength=255, example="Кухня"),
+ *         @OA\Property(property="en", type="string", maxLength=255, example="Kitchen"),
+ *         @OA\Property(property="es", type="string", maxLength=255, example="Cocina")
+ *     ),
+ *     @OA\Property(
+ *         property="image",
+ *         type="string",
+ *         format="binary",
+ *         nullable=true,
+ *         description="Optional replacement cover image (jpeg/png/webp, max 5 MB). Omit to keep the existing one."
+ *     )
+ * )
+ */
+class UpdateLevelRequest extends FormRequest
+{
+    /**
+     * Authorization is delegated to the route middleware (auth + EnsureAdmin).
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => 'required|array',
+            'title.uk' => 'required|string|max:255',
+            'title.en' => 'required|string|max:255',
+            'title.es' => 'required|string|max:255',
+            'image' => 'nullable|file|mimes:jpeg,png,webp|max:5120',
+        ];
+    }
+
+    /**
+     * Convert validation failures into a JSON 422 instead of the default redirect.
+     *
+     * @throws HttpResponseException
+     */
+    protected function failedValidation(Validator $validator): void
+    {
+        throw new HttpResponseException(response()->json([
+            'message' => __('validation.failed_message'),
+            'errors' => $validator->errors(),
+        ], 422));
+    }
+}

--- a/laravel/app/Http/Requests/Admin/UpdateLevelRequest.php
+++ b/laravel/app/Http/Requests/Admin/UpdateLevelRequest.php
@@ -2,9 +2,8 @@
 
 namespace App\Http\Requests\Admin;
 
-use Illuminate\Contracts\Validation\Validator;
+use App\Traits\RespondsWithJsonValidation;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Http\Exceptions\HttpResponseException;
 
 /**
  * Validates an admin "update level" request. Same shape as StoreLevelRequest
@@ -37,6 +36,8 @@ use Illuminate\Http\Exceptions\HttpResponseException;
  */
 class UpdateLevelRequest extends FormRequest
 {
+    use RespondsWithJsonValidation;
+
     /**
      * Authorization is delegated to the route middleware (auth + EnsureAdmin).
      */
@@ -57,18 +58,5 @@ class UpdateLevelRequest extends FormRequest
             'title.es' => 'required|string|max:255',
             'image' => 'nullable|file|mimes:jpeg,png,webp|max:5120',
         ];
-    }
-
-    /**
-     * Convert validation failures into a JSON 422 instead of the default redirect.
-     *
-     * @throws HttpResponseException
-     */
-    protected function failedValidation(Validator $validator): void
-    {
-        throw new HttpResponseException(response()->json([
-            'message' => __('validation.failed_message'),
-            'errors' => $validator->errors(),
-        ], 422));
     }
 }

--- a/laravel/app/Http/Requests/LoginRequest.php
+++ b/laravel/app/Http/Requests/LoginRequest.php
@@ -2,12 +2,13 @@
 
 namespace App\Http\Requests;
 
-use Illuminate\Contracts\Validation\Validator;
+use App\Traits\RespondsWithJsonValidation;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Http\Exceptions\HttpResponseException;
 
 class LoginRequest extends FormRequest
 {
+    use RespondsWithJsonValidation;
+
     /**
      * Determine if the user is authorized to make this request.
      */
@@ -27,22 +28,5 @@ class LoginRequest extends FormRequest
             'email' => 'required|string|email',
             'password' => 'required|string',
         ];
-    }
-
-    /**
-     * Handle a failed validation attempt.
-     *
-     * @param  \Illuminate\Contracts\Validation\Validator  $validator
-     *                                                                 The validator instance containing the failed validation rules.
-     *
-     * @throws \Illuminate\Http\Exceptions\HttpResponseException
-     *                                                           Thrown to immediately return a JSON response with validation errors and a 422 status code.
-     */
-    protected function failedValidation(Validator $validator): void
-    {
-        throw new HttpResponseException(response()->json([
-            'message' => __('validation.failed_message'),
-            'errors' => $validator->errors(),
-        ], 422));
     }
 }

--- a/laravel/app/Http/Requests/RegisterRequest.php
+++ b/laravel/app/Http/Requests/RegisterRequest.php
@@ -2,9 +2,8 @@
 
 namespace App\Http\Requests;
 
-use Illuminate\Contracts\Validation\Validator;
+use App\Traits\RespondsWithJsonValidation;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Validation\Rules\Password;
 
 /**
@@ -14,6 +13,8 @@ use Illuminate\Validation\Rules\Password;
  */
 class RegisterRequest extends FormRequest
 {
+    use RespondsWithJsonValidation;
+
     /**
      * Determine if the user is authorized to make this request.
      */
@@ -34,22 +35,5 @@ class RegisterRequest extends FormRequest
             'email' => 'required|string|email|unique:users',
             'password' => ['required', 'string', 'confirmed', Password::min(8)->mixedCase()->numbers()],
         ];
-    }
-
-    /**
-     * Handle a failed validation attempt.
-     *
-     * @param  \Illuminate\Contracts\Validation\Validator  $validator
-     *                                                                 The validator instance containing the failed validation rules.
-     *
-     * @throws \Illuminate\Http\Exceptions\HttpResponseException
-     *                                                           Thrown to immediately return a JSON response with validation errors and a 422 status code.
-     */
-    protected function failedValidation(Validator $validator): void
-    {
-        throw new HttpResponseException(response()->json([
-            'message' => __('validation.failed_message'),
-            'errors' => $validator->errors(),
-        ], 422));
     }
 }

--- a/laravel/app/Http/Requests/UpdatePasswordRequest.php
+++ b/laravel/app/Http/Requests/UpdatePasswordRequest.php
@@ -2,9 +2,8 @@
 
 namespace App\Http\Requests;
 
-use Illuminate\Contracts\Validation\Validator;
+use App\Traits\RespondsWithJsonValidation;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Validation\Rules\Password;
 
 /**
@@ -13,6 +12,8 @@ use Illuminate\Validation\Rules\Password;
  */
 class UpdatePasswordRequest extends FormRequest
 {
+    use RespondsWithJsonValidation;
+
     /**
      * Determine if the user is authorized to make this request.
      */
@@ -32,19 +33,5 @@ class UpdatePasswordRequest extends FormRequest
             'current_password' => ['required', 'string', 'current_password'],
             'new_password' => ['required', 'string', 'confirmed', Password::min(8)->mixedCase()->numbers()],
         ];
-    }
-
-    /**
-     * Handle a failed validation attempt.
-     *
-     *
-     * @throws \Illuminate\Http\Exceptions\HttpResponseException
-     */
-    protected function failedValidation(Validator $validator): void
-    {
-        throw new HttpResponseException(response()->json([
-            'message' => __('validation.failed_message'),
-            'errors' => $validator->errors(),
-        ], 422));
     }
 }

--- a/laravel/app/Http/Resources/Admin/LevelAdminResource.php
+++ b/laravel/app/Http/Resources/Admin/LevelAdminResource.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Resources\Admin;
+
+use App\Contracts\TranslatableLevelInterface;
+use App\Models\Level;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Admin-side level shape. Returns the full translations map for `title` so the
+ * admin form can edit every locale; the public LevelDescriptionResource emits
+ * only the current locale's string.
+ */
+class LevelAdminResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string,mixed>
+     */
+    public function toArray(Request $request): array
+    {
+
+        /** @var Level&TranslatableLevelInterface $level */
+        $level = $this->resource;
+
+        return [
+            'id' => $level->id,
+            'title' => $level->getTranslations('title'),
+            'image_url' => $level->image_url,
+            'items_count' => $this->whenCounted('items'),
+        ];
+    }
+}

--- a/laravel/app/Models/Level.php
+++ b/laravel/app/Models/Level.php
@@ -43,20 +43,32 @@ class Level extends Model
 
     public function getImageUrlAttribute(): string
     {
-        $diskName = ConfigHelper::getString('games.default_icon_disk', 'static');
-
-        /** @var \Illuminate\Filesystem\FilesystemAdapter $disk */
-        $disk = \Illuminate\Support\Facades\Storage::disk($diskName);
-
         $raw = $this->attributes['image_url'] ?? null;
         $path = is_string($raw) ? ltrim($raw, '/') : '';
 
-        $key = $path !== '' && $disk->exists($path)
+        if ($path !== '') {
+            $uploadDiskName = ConfigHelper::getString('games.upload_disk', 'public');
+            /** @var \Illuminate\Filesystem\FilesystemAdapter $uploadDisk */
+            $uploadDisk = \Illuminate\Support\Facades\Storage::disk($uploadDiskName);
+
+            if ($uploadDisk->exists($path)) {
+                return $this->absoluteUrl($uploadDisk->url($path));
+            }
+        }
+
+        $staticDiskName = ConfigHelper::getString('games.default_icon_disk', 'static');
+        /** @var \Illuminate\Filesystem\FilesystemAdapter $staticDisk */
+        $staticDisk = \Illuminate\Support\Facades\Storage::disk($staticDiskName);
+
+        $key = $path !== '' && $staticDisk->exists($path)
             ? $path
             : ConfigHelper::getString('games.default_level_image', 'icons/default-icon.png');
 
-        $url = $disk->url($key);
+        return $this->absoluteUrl($staticDisk->url($key));
+    }
 
+    private function absoluteUrl(string $url): string
+    {
         return str_starts_with($url, 'http://') || str_starts_with($url, 'https://')
             ? $url
             : url($url);

--- a/laravel/app/Models/Level.php
+++ b/laravel/app/Models/Level.php
@@ -5,6 +5,8 @@ namespace App\Models;
 use App\Helpers\ConfigHelper;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Support\Facades\Storage;
 
 /**
  * @property int $id
@@ -48,8 +50,8 @@ class Level extends Model
 
         if ($path !== '') {
             $uploadDiskName = ConfigHelper::getString('games.upload_disk', 'public');
-            /** @var \Illuminate\Filesystem\FilesystemAdapter $uploadDisk */
-            $uploadDisk = \Illuminate\Support\Facades\Storage::disk($uploadDiskName);
+            /** @var FilesystemAdapter $uploadDisk */
+            $uploadDisk = Storage::disk($uploadDiskName);
 
             if ($uploadDisk->exists($path)) {
                 return $this->absoluteUrl($uploadDisk->url($path));
@@ -57,8 +59,8 @@ class Level extends Model
         }
 
         $staticDiskName = ConfigHelper::getString('games.default_icon_disk', 'static');
-        /** @var \Illuminate\Filesystem\FilesystemAdapter $staticDisk */
-        $staticDisk = \Illuminate\Support\Facades\Storage::disk($staticDiskName);
+        /** @var FilesystemAdapter $staticDisk */
+        $staticDisk = Storage::disk($staticDiskName);
 
         $key = $path !== '' && $staticDisk->exists($path)
             ? $path

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -16,6 +16,7 @@ use Laravel\Sanctum\HasApiTokens;
  * @property string|null $google_id
  * @property string|null $avatar
  * @property string|null $password
+ * @property bool $is_admin
  * @property \Illuminate\Support\Carbon|null $email_verified_at
  * @property \Illuminate\Support\Carbon $created_at
  * @property \Illuminate\Support\Carbon $updated_at
@@ -36,6 +37,7 @@ class User extends Authenticatable
         'password',
         'google_id',
         'avatar',
+        'is_admin',
     ];
 
     /**
@@ -55,6 +57,7 @@ class User extends Authenticatable
      */
     protected $casts = [
         'email_verified_at' => 'datetime',
+        'is_admin' => 'boolean',
     ];
 
     public function gameResults(): HasMany

--- a/laravel/app/Services/LevelAdminServiceFactory.php
+++ b/laravel/app/Services/LevelAdminServiceFactory.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Services;
+
+use App\Contracts\LevelAdminServiceInterface;
+use App\Helpers\ConfigHelper;
+use App\Models\Game;
+use Illuminate\Contracts\Container\Container;
+use InvalidArgumentException;
+
+/**
+ * Resolves the admin-side level service for a given Game by its table_prefix.
+ * Mirrors GameServiceFactory but for write/admin operations.
+ */
+class LevelAdminServiceFactory
+{
+    /** @var array<string, string> */
+    protected array $map;
+
+    /**
+     * @param  array<string, string>|null  $map  Optional override of the table_prefix => service-class map, used by tests.
+     */
+    public function __construct(protected Container $container, ?array $map = null)
+    {
+        $this->map = $map ?? ConfigHelper::getStringMap('game_admin_services.map', []);
+    }
+
+    /**
+     * Resolve the admin service for the given game by its table_prefix.
+     *
+     * @throws InvalidArgumentException If no mapping exists, the configured class is missing,
+     *                                  or the resolved instance does not implement the contract.
+     */
+    public function for(Game $game): LevelAdminServiceInterface
+    {
+        $key = $game->table_prefix ?? null;
+
+        if ($key === null || ! isset($this->map[$key])) {
+            throw new InvalidArgumentException("Admin operations are not configured for game prefix: {$key}");
+        }
+
+        $serviceClass = $this->map[$key];
+
+        if (! class_exists($serviceClass)) {
+            throw new InvalidArgumentException("Admin service class {$serviceClass} not found for game prefix {$key}");
+        }
+
+        $service = $this->container->make($serviceClass);
+
+        if (! $service instanceof LevelAdminServiceInterface) {
+            throw new InvalidArgumentException("{$serviceClass} must implement LevelAdminServiceInterface");
+        }
+
+        return $service;
+    }
+}

--- a/laravel/app/Traits/RespondsWithJsonValidation.php
+++ b/laravel/app/Traits/RespondsWithJsonValidation.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+/**
+ * Force JSON 422 on validation failure regardless of the request's Accept header.
+ * Applied to FormRequests in API contexts where redirects are never desired —
+ * keeps the failure payload identical to the rest of the API surface.
+ */
+trait RespondsWithJsonValidation
+{
+    /**
+     * @throws HttpResponseException
+     */
+    protected function failedValidation(Validator $validator): void
+    {
+        throw new HttpResponseException(response()->json([
+            'message' => __('validation.failed_message'),
+            'errors' => $validator->errors(),
+        ], 422));
+    }
+}

--- a/laravel/config/game_admin_services.php
+++ b/laravel/config/game_admin_services.php
@@ -1,0 +1,15 @@
+<?php
+
+use App\Contracts\LevelAdminServiceInterface;
+use App\Games\FindTheWrong\Services\Admin\FindTheWrongLevelAdminService;
+
+return [
+    /**
+     * Map game table_prefix to admin service class for level CRUD.
+     *
+     * @var array<string, class-string<LevelAdminServiceInterface>>
+     */
+    'map' => [
+        'find_the_wrong' => FindTheWrongLevelAdminService::class,
+    ],
+];

--- a/laravel/config/games.php
+++ b/laravel/config/games.php
@@ -4,4 +4,11 @@ return [
     'default_icon' => 'icons/default-icon.png',
     'default_level_image' => 'icons/default-icon.png',
     'default_icon_disk' => 'static',
+
+    /*
+    | Disk for admin-uploaded game assets (level images, etc.). Local dev
+    | uses the public disk; production points at the configured cloud
+    | bucket via env override.
+    */
+    'upload_disk' => env('GAMES_UPLOAD_DISK', 'public'),
 ];

--- a/laravel/database/factories/Games/FindTheWrong/Models/FindTheWrongLevelFactory.php
+++ b/laravel/database/factories/Games/FindTheWrong/Models/FindTheWrongLevelFactory.php
@@ -23,7 +23,7 @@ class FindTheWrongLevelFactory extends Factory
                 'en' => $this->faker->sentence(3),
                 'es' => $this->faker->sentence(3),
             ],
-            'image_url' => 'games/find-the-wrong/levels/image.jpg',
+            'image_url' => FindTheWrongLevel::STORAGE_ROOT.'/image.jpg',
         ];
     }
 }

--- a/laravel/database/factories/UserFactory.php
+++ b/laravel/database/factories/UserFactory.php
@@ -37,4 +37,16 @@ class UserFactory extends Factory
             'email_verified_at' => null,
         ]);
     }
+
+    /**
+     * Indicate that the user has admin privileges.
+     *
+     * @return $this
+     */
+    public function admin(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_admin' => true,
+        ]);
+    }
 }

--- a/laravel/database/migrations/2026_05_29_120020_add_is_admin_to_users_table.php
+++ b/laravel/database/migrations/2026_05_29_120020_add_is_admin_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('is_admin')->default(false)->after('avatar');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('is_admin');
+        });
+    }
+};

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -1,11 +1,13 @@
 <?php
 
+use App\Http\Controllers\Admin\LevelController as AdminLevelController;
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\GameController;
 use App\Http\Controllers\GoogleAuthController;
 use App\Http\Controllers\LevelController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\ProfilePasswordController;
+use App\Http\Middleware\EnsureAdmin;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -43,3 +45,18 @@ Route::middleware('auth:sanctum')->group(function () {
         ->whereNumber(['game', 'level']);
 
 });
+
+Route::middleware(['auth:sanctum', EnsureAdmin::class])
+    ->prefix('admin/games/{game}')
+    ->name('admin.games.levels.')
+    ->whereNumber('game')
+    ->group(function () {
+        Route::get('levels', [AdminLevelController::class, 'index'])->name('index');
+        Route::post('levels', [AdminLevelController::class, 'store'])->name('store');
+        Route::match(['put', 'patch'], 'levels/{level}', [AdminLevelController::class, 'update'])
+            ->name('update')
+            ->whereNumber('level');
+        Route::delete('levels/{level}', [AdminLevelController::class, 'destroy'])
+            ->name('destroy')
+            ->whereNumber('level');
+    });

--- a/laravel/tests/Feature/Games/FindTheWrong/Admin/FindTheWrongLevelAdminControllerTest.php
+++ b/laravel/tests/Feature/Games/FindTheWrong/Admin/FindTheWrongLevelAdminControllerTest.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Tests\Feature\Games\FindTheWrong\Admin;
+
+use App\Games\FindTheWrong\Models\FindTheWrongItem;
+use App\Games\FindTheWrong\Models\FindTheWrongLevel;
+use App\Models\Game;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class FindTheWrongLevelAdminControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Game $game;
+
+    private string $route;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Storage::fake('public');
+        config(['games.upload_disk' => 'public']);
+
+        $this->game = Game::factory()->create(['table_prefix' => 'find_the_wrong']);
+        $this->route = "/api/admin/games/{$this->game->id}/levels";
+    }
+
+    public function test_unauthenticated_request_is_rejected(): void
+    {
+        $this->getJson($this->route)->assertStatus(401);
+        $this->postJson($this->route, [])->assertStatus(401);
+    }
+
+    public function test_non_admin_user_is_forbidden(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)->getJson($this->route)->assertStatus(403);
+        $this->actingAs($user)->postJson($this->route, [])->assertStatus(403);
+    }
+
+    public function test_admin_creates_level_with_image(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $image = UploadedFile::fake()->image('kitchen.png', 800, 600);
+
+        $response = $this->actingAs($admin)->postJson($this->route, [
+            'title' => ['uk' => 'Кухня', 'en' => 'Kitchen', 'es' => 'Cocina'],
+            'image' => $image,
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonStructure(['id', 'title', 'image_url'])
+            ->assertJsonPath('title.uk', 'Кухня')
+            ->assertJsonPath('title.en', 'Kitchen');
+
+        $level = FindTheWrongLevel::query()->findOrFail($response->json('id'));
+        $expectedPath = $level->storageDirectory().'/image.png';
+
+        Storage::disk('public')->assertExists($expectedPath);
+        $this->assertSame($expectedPath, $level->getRawOriginal('image_url'));
+    }
+
+    public function test_admin_update_title_without_image_keeps_existing_image(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $level = FindTheWrongLevel::factory()->create([
+            'title' => ['uk' => 'Старе', 'en' => 'Old', 'es' => 'Viejo'],
+        ]);
+        $existingPath = $level->storageDirectory().'/image.jpg';
+        Storage::disk('public')->put($existingPath, 'fake-image-bytes');
+        $level->update(['image_url' => $existingPath]);
+
+        $response = $this->actingAs($admin)->patchJson("{$this->route}/{$level->id}", [
+            'title' => ['uk' => 'Нове', 'en' => 'New', 'es' => 'Nuevo'],
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('title.en', 'New');
+
+        $level->refresh();
+        $this->assertSame($existingPath, $level->getRawOriginal('image_url'));
+        Storage::disk('public')->assertExists($existingPath);
+    }
+
+    public function test_admin_update_with_new_image_replaces_old_file(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $level = FindTheWrongLevel::factory()->create([
+            'title' => ['uk' => 'Кухня', 'en' => 'Kitchen', 'es' => 'Cocina'],
+            'image_url' => null,
+        ]);
+        $oldPath = $level->storageDirectory().'/image.jpg';
+        Storage::disk('public')->put($oldPath, 'old');
+        $level->update(['image_url' => $oldPath]);
+
+        $newImage = UploadedFile::fake()->image('bathroom.png', 800, 600);
+
+        $response = $this->actingAs($admin)->postJson("{$this->route}/{$level->id}?_method=PATCH", [
+            'title' => ['uk' => 'Кухня', 'en' => 'Kitchen', 'es' => 'Cocina'],
+            'image' => $newImage,
+        ]);
+
+        $response->assertStatus(200);
+
+        $level->refresh();
+        $newPath = $level->storageDirectory().'/image.png';
+        $this->assertSame($newPath, $level->getRawOriginal('image_url'));
+        Storage::disk('public')->assertExists($newPath);
+        Storage::disk('public')->assertMissing($oldPath);
+    }
+
+    public function test_admin_destroy_cascades_items_and_cleans_storage(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $level = FindTheWrongLevel::factory()->create();
+        $items = FindTheWrongItem::factory()->count(3)->create(['level_id' => $level->id]);
+
+        $path = $level->storageDirectory().'/image.png';
+        Storage::disk('public')->put($path, 'bytes');
+        $level->update(['image_url' => $path]);
+
+        $response = $this->actingAs($admin)->deleteJson("{$this->route}/{$level->id}");
+
+        $response->assertStatus(204);
+
+        $this->assertDatabaseMissing('find_the_wrong_levels', ['id' => $level->id]);
+        foreach ($items as $item) {
+            $this->assertDatabaseMissing('find_the_wrong_items', ['id' => $item->id]);
+        }
+        Storage::disk('public')->assertMissing($path);
+    }
+
+    public function test_store_validation_requires_title_and_image(): void
+    {
+        $admin = User::factory()->admin()->create();
+
+        $this->actingAs($admin)
+            ->postJson($this->route, [])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['title', 'image']);
+
+        $this->actingAs($admin)
+            ->postJson($this->route, [
+                'title' => ['en' => 'Only English'],
+                'image' => UploadedFile::fake()->image('foo.png'),
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['title.uk', 'title.es']);
+    }
+
+    public function test_index_returns_levels_with_items_count(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $level = FindTheWrongLevel::factory()->create();
+        FindTheWrongItem::factory()->count(2)->create(['level_id' => $level->id]);
+
+        $response = $this->actingAs($admin)->getJson($this->route);
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([['id', 'title', 'image_url', 'items_count']])
+            ->assertJsonPath('0.items_count', 2);
+    }
+
+    public function test_admin_endpoint_rejects_game_without_admin_service(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $otherGame = Game::factory()->create(['table_prefix' => 'true_false_image']);
+
+        $this->actingAs($admin)
+            ->getJson("/api/admin/games/{$otherGame->id}/levels")
+            ->assertStatus(400);
+    }
+}

--- a/laravel/tests/Feature/Games/FindTheWrong/Admin/FindTheWrongLevelAdminControllerTest.php
+++ b/laravel/tests/Feature/Games/FindTheWrong/Admin/FindTheWrongLevelAdminControllerTest.php
@@ -173,6 +173,7 @@ class FindTheWrongLevelAdminControllerTest extends TestCase
 
         $this->actingAs($admin)
             ->getJson("/api/admin/games/{$otherGame->id}/levels")
-            ->assertStatus(400);
+            ->assertStatus(404)
+            ->assertJsonPath('message', 'Admin operations are not available for this game.');
     }
 }

--- a/laravel/tests/Feature/Games/FindTheWrong/Admin/FindTheWrongLevelAdminControllerTest.php
+++ b/laravel/tests/Feature/Games/FindTheWrong/Admin/FindTheWrongLevelAdminControllerTest.php
@@ -169,7 +169,7 @@ class FindTheWrongLevelAdminControllerTest extends TestCase
     public function test_admin_endpoint_rejects_game_without_admin_service(): void
     {
         $admin = User::factory()->admin()->create();
-        $otherGame = Game::factory()->create(['table_prefix' => 'true_false_image']);
+        $otherGame = Game::factory()->create(['table_prefix' => 'definitely_not_registered']);
 
         $this->actingAs($admin)
             ->getJson("/api/admin/games/{$otherGame->id}/levels")

--- a/laravel/tests/Unit/Http/Middleware/EnsureAdminTest.php
+++ b/laravel/tests/Unit/Http/Middleware/EnsureAdminTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Unit\Http\Middleware;
+
+use App\Http\Middleware\EnsureAdmin;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Tests\TestCase;
+
+class EnsureAdminTest extends TestCase
+{
+    private EnsureAdmin $middleware;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->middleware = new EnsureAdmin;
+    }
+
+    public function test_returns_401_when_request_has_no_user(): void
+    {
+        $request = Request::create('/test');
+
+        try {
+            $this->middleware->handle($request, fn () => null);
+            $this->fail('Expected HttpException to be thrown.');
+        } catch (HttpException $e) {
+            $this->assertSame(401, $e->getStatusCode());
+        }
+    }
+
+    public function test_returns_403_when_user_is_not_admin(): void
+    {
+        $request = Request::create('/test');
+        $request->setUserResolver(fn () => new User(['is_admin' => false]));
+
+        try {
+            $this->middleware->handle($request, fn () => null);
+            $this->fail('Expected HttpException to be thrown.');
+        } catch (HttpException $e) {
+            $this->assertSame(403, $e->getStatusCode());
+        }
+    }
+
+    public function test_passes_through_admin_user(): void
+    {
+        $request = Request::create('/test');
+        $request->setUserResolver(fn () => new User(['is_admin' => true]));
+
+        $response = $this->middleware->handle($request, fn () => response('ok'));
+
+        $this->assertSame('ok', $response->getContent());
+    }
+}


### PR DESCRIPTION
 - [x] Implement admin auth: is_admin migration + User model/factory + EnsureAdmin middleware (FQN in routes, no Kernel alias)
 - [x] Config uUpload disk: config('games.upload_disk') env-overridable + Level::getImageUrlAttribute two-tier (upload disk → static fallback)
 - [x] Implement dispatcher: LevelAdminServiceInterface + LevelAdminServiceFactory + generic Admin\LevelController + Admin\StoreLevelRequest/UpdateLevelRequest + config/game_admin_services.php
 - [x] Implement FindTheWrong service
 - [x] Create routes /api/admin/games/{game}/levels[/{level}] under auth:sanctum + EnsureAdmin::class
 - [x] Create PHPDoc on every admin fileservice
 - [x] Create feature tests