### PR TITLE
refactor(api): enable JsonResource::withoutWrapping globally ss-126

### DIFF
--- a/laravel/app/Games/FindTheWrong/Http/Controllers/Admin/FindTheWrongItemController.php
+++ b/laravel/app/Games/FindTheWrong/Http/Controllers/Admin/FindTheWrongItemController.php
@@ -9,6 +9,7 @@ use App\Games\FindTheWrong\Services\Admin\FindTheWrongItemAdminService;
 use App\Http\Controllers\Controller;
 use App\Models\Game;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Response;
 
 /**
@@ -30,19 +31,16 @@ class FindTheWrongItemController extends Controller
     {
         $item = $this->service->create($level, $request->validated());
 
-        return response()->json(
-            FindTheWrongItemAdminResource::make($item)->resolve(request()),
-            201
-        );
+        return FindTheWrongItemAdminResource::make($item)
+            ->response()
+            ->setStatusCode(201);
     }
 
-    public function update(UpdateItemRequest $request, Game $game, int $item): JsonResponse
+    public function update(UpdateItemRequest $request, Game $game, int $item): JsonResource
     {
         $updated = $this->service->update($item, $request->validated());
 
-        return response()->json(
-            FindTheWrongItemAdminResource::make($updated)->resolve(request())
-        );
+        return FindTheWrongItemAdminResource::make($updated);
     }
 
     public function destroy(Game $game, int $item): Response

--- a/laravel/app/Http/Controllers/Admin/LevelController.php
+++ b/laravel/app/Http/Controllers/Admin/LevelController.php
@@ -10,6 +10,7 @@ use App\Http\Resources\Admin\LevelAdminResource;
 use App\Models\Game;
 use App\Services\LevelAdminServiceFactory;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Response;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Log;
@@ -26,13 +27,11 @@ class LevelController extends Controller
     /**
      * List all levels for the given game (admin view, includes items_count).
      */
-    public function index(Game $game): JsonResponse
+    public function index(Game $game): JsonResource
     {
         $service = $this->resolveService($game);
 
-        return response()->json(
-            LevelAdminResource::collection($service->list())->resolve(request())
-        );
+        return LevelAdminResource::collection($service->list());
     }
 
     /**
@@ -49,16 +48,15 @@ class LevelController extends Controller
             'title' => $request->validated('title'),
         ], $image);
 
-        return response()->json(
-            LevelAdminResource::make($level)->resolve(request()),
-            201
-        );
+        return LevelAdminResource::make($level)
+            ->response()
+            ->setStatusCode(201);
     }
 
     /**
      * Update a level's metadata; image is replaced only when a file is attached.
      */
-    public function update(UpdateLevelRequest $request, Game $game, int $level): JsonResponse
+    public function update(UpdateLevelRequest $request, Game $game, int $level): JsonResource
     {
         $service = $this->resolveService($game);
 
@@ -69,9 +67,7 @@ class LevelController extends Controller
             'title' => $request->validated('title'),
         ], $image);
 
-        return response()->json(
-            LevelAdminResource::make($updated)->resolve(request())
-        );
+        return LevelAdminResource::make($updated);
     }
 
     /**

--- a/laravel/app/Http/Controllers/GameController.php
+++ b/laravel/app/Http/Controllers/GameController.php
@@ -4,8 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Resources\GameResource;
 use App\Models\Game;
-use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
 
 class GameController extends Controller
 {
@@ -31,7 +30,7 @@ class GameController extends Controller
      *     )
      * )
      */
-    public function index(): JsonResponse
+    public function index(): JsonResource
     {
         $games = Game::where('is_active', true)->get([
             'id',
@@ -40,7 +39,7 @@ class GameController extends Controller
             'is_active',
         ]);
 
-        return response()->json(GameResource::collection($games));
+        return GameResource::collection($games);
     }
 
     // /**
@@ -93,9 +92,9 @@ class GameController extends Controller
      * )
      * )
      */
-    public function show(Game $game): JsonResponse
+    public function show(Game $game): JsonResource
     {
-        return response()->json(new GameResource($game));
+        return new GameResource($game);
     }
 
     // /**

--- a/laravel/app/Http/Controllers/LevelController.php
+++ b/laravel/app/Http/Controllers/LevelController.php
@@ -10,6 +10,7 @@ use App\Services\GameResultService;
 use App\Services\GameServiceFactory;
 use App\Services\ResourceResolver;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\JsonResource;
 use InvalidArgumentException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -68,7 +69,7 @@ class LevelController extends Controller
      *     )
      * )
      */
-    public function index(Game $game): JsonResponse
+    public function index(Game $game): JsonResource|JsonResponse
     {
         try {
             $service = $this->factory->for($game);
@@ -79,7 +80,7 @@ class LevelController extends Controller
             return response()->json(['message' => $e->getMessage()], 400);
         }
 
-        return response()->json(LevelDescriptionResource::collection($levels)->resolve(request()), 200);
+        return LevelDescriptionResource::collection($levels);
     }
 
     /**
@@ -132,7 +133,7 @@ class LevelController extends Controller
      *     )
      * )
      */
-    public function show(Game $game, int $levelId): JsonResponse
+    public function show(Game $game, int $levelId): JsonResource|JsonResponse
     {
         try {
             $service = $this->factory->for($game);
@@ -145,9 +146,7 @@ class LevelController extends Controller
             return response()->json(['message' => $e->getMessage()], 404);
         }
 
-        $resource = $this->resources->resourceFor($game, $level);
-
-        return response()->json($resource->resolve(request()), 200);
+        return $this->resources->resourceFor($game, $level);
     }
 
     /**

--- a/laravel/app/Http/Controllers/ProfileController.php
+++ b/laravel/app/Http/Controllers/ProfileController.php
@@ -4,8 +4,8 @@ namespace App\Http\Controllers;
 
 use App\Http\Resources\ProfileResource;
 use App\Services\ProfileAggregationService;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
 
 class ProfileController extends Controller
 {
@@ -37,13 +37,13 @@ class ProfileController extends Controller
      *     )
      * )
      */
-    public function show(Request $request): JsonResponse
+    public function show(Request $request): JsonResource
     {
         /** @var \App\Models\User $user */
         $user = $request->user();
 
         $stats = $this->profileAggregationService->aggregate($user);
 
-        return response()->json((new ProfileResource($user, $stats))->resolve($request));
+        return new ProfileResource($user, $stats);
     }
 }

--- a/laravel/app/Providers/AppServiceProvider.php
+++ b/laravel/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +20,10 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        // API contract: flat shape (no "data" envelope) for single + non-paginated
+        // collection endpoints. Pagination, when needed, should opt into envelope
+        // via dedicated PaginatedResourceCollection subclasses that explicitly
+        // return {data, meta} from toArray().
+        JsonResource::withoutWrapping();
     }
 }


### PR DESCRIPTION
- [x] Add `JsonResource::withoutWrapping();` to `AppServiceProvider::boot()`
- [x] Replace `response()->json($resource->resolve(request()), $status)` with:
  - `return $resource;` for 200
  - `return $resource->response()->setStatusCode($status);` 