### PR TITLE
feat(games): add tts observers for find the wrong ss-132

### DIFF
--- a/laravel/app/Console/Commands/Tts/TtsSyncCommand.php
+++ b/laravel/app/Console/Commands/Tts/TtsSyncCommand.php
@@ -6,7 +6,6 @@ use App\Contracts\TtsAudioInterface;
 use App\Enums\Tts\TtsModelMappingEnum;
 use App\Helpers\ConfigHelper;
 use App\Jobs\Tts\GenerateTtsAudioJob;
-use App\Services\Tts\DTO\TtsAudioContext;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Log;
@@ -74,9 +73,7 @@ class TtsSyncCommand extends Command
                                 continue;
                             }
 
-                            GenerateTtsAudioJob::dispatch(
-                                TtsAudioContext::make($record, $audioAttr, $locale, $text)
-                            );
+                            GenerateTtsAudioJob::dispatch($record, $audioAttr, $locale, $text);
 
                             $modelCount++;
                             $totalCount++;

--- a/laravel/app/Contracts/TtsAudioInterface.php
+++ b/laravel/app/Contracts/TtsAudioInterface.php
@@ -43,4 +43,14 @@ interface TtsAudioInterface
      * @param  string  $path  The path to the audio file
      */
     public function setAudioPath(string $attribute, string $locale, string $path): void;
+
+    /**
+     * List the model's audio-URL attributes — i.e. translatable fields whose
+     * source text should drive TTS generation. By convention each audio
+     * attribute pairs with a source attribute named identically minus the
+     * `_audio_url` suffix.
+     *
+     * @return array<int, string> e.g. ['name_audio_url', 'explanation_audio_url']
+     */
+    public function getTtsAudioAttributes(): array;
 }

--- a/laravel/app/Jobs/Tts/GenerateTtsAudioJob.php
+++ b/laravel/app/Jobs/Tts/GenerateTtsAudioJob.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs\Tts;
 
+use App\Contracts\TtsAudioInterface;
 use App\Enums\TtsLogEventEnum;
 use App\Exceptions\Tts\TtsQuotaExceededException;
 use App\Helpers\ConfigHelper;
@@ -9,6 +10,7 @@ use App\Services\Tts\DTO\TtsAudioContext;
 use App\Services\Tts\TtsAudioGeneratorService;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
@@ -32,12 +34,21 @@ class GenerateTtsAudioJob implements ShouldQueue
     public int $backoff = 60;
 
     /**
-     * Create a new job instance.
+     * Direct model + attribute + locale (instead of wrapping in TtsAudioContext)
+     * so SerializesModels replaces $model with a lightweight ModelIdentifier
+     * during queue serialization. Wrapping the model inside a DTO would bypass
+     * this optimization — the entire model object would be serialized, causing
+     * payload bloat and stale-data risk.
      *
-     * @param  TtsAudioContext  $context  The TTS audio context
+     * Text is optional: lazy-path callers (listener, sync command) pass it
+     * pre-resolved; observer path leaves it null and lets the generator
+     * extract it fresh from the (re-loaded) model.
      */
     public function __construct(
-        public readonly TtsAudioContext $context,
+        public readonly TtsAudioInterface&Model $model,
+        public readonly string $attribute,
+        public readonly string $locale,
+        public readonly ?string $text = null,
     ) {
         $this->onQueue(ConfigHelper::getString('ai.tts.auto_generate.queue', 'tts'));
     }
@@ -47,14 +58,16 @@ class GenerateTtsAudioJob implements ShouldQueue
      */
     public function handle(TtsAudioGeneratorService $audioGenerator, LoggerInterface $logger): void
     {
-        try {
-            $logger->info('Starting TTS audio generation via Job', $this->context->toLogContext());
+        $context = TtsAudioContext::make($this->model, $this->attribute, $this->locale, $this->text);
 
-            $audioGenerator->generateForModel($this->context);
+        try {
+            $logger->info('Starting TTS audio generation via Job', $context->toLogContext());
+
+            $audioGenerator->generateForModel($context);
 
         } catch (TtsQuotaExceededException $e) {
             $logger->error(TtsLogEventEnum::PROVIDER_QUOTA_EXCEEDED->value, [
-                ...$this->context->toLogContext(),
+                ...$context->toLogContext(),
                 'error' => $e->getMessage(),
             ]);
 
@@ -62,7 +75,7 @@ class GenerateTtsAudioJob implements ShouldQueue
             $this->release($this->calculateBackoff());
         } catch (\Throwable $e) {
             $logger->error(TtsLogEventEnum::SYNTHESIS_FAILED->value, [
-                ...$this->context->toLogContext(),
+                ...$context->toLogContext(),
                 'error' => $e->getMessage(),
                 'trace' => $e->getTraceAsString(),
             ]);

--- a/laravel/app/Listeners/GenerateMissingAudioListener.php
+++ b/laravel/app/Listeners/GenerateMissingAudioListener.php
@@ -81,7 +81,12 @@ class GenerateMissingAudioListener
             return false;
         }
 
-        GenerateTtsAudioJob::dispatch($context);
+        GenerateTtsAudioJob::dispatch(
+            $context->getModel(),
+            $context->getAttribute(),
+            $context->getLocale(),
+            $context->getText(),
+        );
 
         $this->logJobDispatched($context);
 

--- a/laravel/app/Observers/ProactiveTtsObserver.php
+++ b/laravel/app/Observers/ProactiveTtsObserver.php
@@ -18,7 +18,7 @@ use Illuminate\Database\Eloquent\Model;
  * registering on a non-TtsAudioInterface model raises TypeError at first
  * save, instead of silently doing nothing.
  */
-class ProactiveTtsObserver
+final class ProactiveTtsObserver
 {
     public function __construct(
         private readonly TtsObserverDispatcher $dispatcher,

--- a/laravel/app/Observers/ProactiveTtsObserver.php
+++ b/laravel/app/Observers/ProactiveTtsObserver.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Observers;
+
+use App\Contracts\TtsAudioInterface;
+use App\Services\Tts\TtsObserverDispatcher;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Single Eloquent observer for any model implementing TtsAudioInterface.
+ *
+ * Registered per-class in EventServiceProvider::$observers — one instance
+ * runs for every TTS-enabled model. The (source → audio_url) mapping comes
+ * from the model itself via `getTtsAudioAttributes()`, so adding a new
+ * audio field to a model requires zero observer changes (OCP).
+ *
+ * Intersection type `TtsAudioInterface&Model` makes misregistration loud:
+ * registering on a non-TtsAudioInterface model raises TypeError at first
+ * save, instead of silently doing nothing.
+ */
+class ProactiveTtsObserver
+{
+    public function __construct(
+        private readonly TtsObserverDispatcher $dispatcher,
+    ) {}
+
+    public function created(TtsAudioInterface&Model $model): void
+    {
+        $this->dispatcher->onCreated($model);
+    }
+
+    public function updated(TtsAudioInterface&Model $model): void
+    {
+        $this->dispatcher->onUpdated($model);
+    }
+}

--- a/laravel/app/Providers/EventServiceProvider.php
+++ b/laravel/app/Providers/EventServiceProvider.php
@@ -3,7 +3,10 @@
 namespace App\Providers;
 
 use App\Events\TtsAudioRequestedEvent;
+use App\Games\FindTheWrong\Models\FindTheWrongItem;
+use App\Games\FindTheWrong\Models\FindTheWrongLevel;
 use App\Listeners\GenerateMissingAudioListener;
+use App\Observers\ProactiveTtsObserver;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
@@ -22,6 +25,16 @@ class EventServiceProvider extends ServiceProvider
         TtsAudioRequestedEvent::class => [
             GenerateMissingAudioListener::class,
         ],
+    ];
+
+    /**
+     * The model observers to register.
+     *
+     * @var array<class-string, class-string|array<int, class-string>>
+     */
+    protected $observers = [
+        FindTheWrongItem::class => [ProactiveTtsObserver::class],
+        FindTheWrongLevel::class => [ProactiveTtsObserver::class],
     ];
 
     /**

--- a/laravel/app/Providers/EventServiceProvider.php
+++ b/laravel/app/Providers/EventServiceProvider.php
@@ -40,10 +40,7 @@ class EventServiceProvider extends ServiceProvider
     /**
      * Register any events for your application.
      */
-    public function boot(): void
-    {
-        //
-    }
+    public function boot(): void {}
 
     /**
      * Determine if events and listeners should be automatically discovered.

--- a/laravel/app/Services/Tts/TtsAudioGeneratorService.php
+++ b/laravel/app/Services/Tts/TtsAudioGeneratorService.php
@@ -160,7 +160,7 @@ class TtsAudioGeneratorService
      */
     private function validateText(?string $text, TtsAudioContext $context): bool
     {
-        if (! $text) {
+        if ($text === null || $text === '') {
             $this->logger->warning('No text content found for TTS generation', $context->toLogContext());
 
             return false;

--- a/laravel/app/Services/Tts/TtsObserverDispatcher.php
+++ b/laravel/app/Services/Tts/TtsObserverDispatcher.php
@@ -5,7 +5,6 @@ namespace App\Services\Tts;
 use App\Contracts\TtsAudioInterface;
 use App\Helpers\ConfigHelper;
 use App\Jobs\Tts\GenerateTtsAudioJob;
-use App\Services\Tts\DTO\TtsAudioContext;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -100,9 +99,7 @@ final class TtsObserverDispatcher
                 continue;
             }
 
-            GenerateTtsAudioJob::dispatch(
-                TtsAudioContext::make($model, $audioAttribute, $locale)
-            );
+            GenerateTtsAudioJob::dispatch($model, $audioAttribute, $locale);
         }
     }
 

--- a/laravel/app/Services/Tts/TtsObserverDispatcher.php
+++ b/laravel/app/Services/Tts/TtsObserverDispatcher.php
@@ -42,7 +42,7 @@ use Illuminate\Database\Eloquent\Model;
  * inside the job itself — that single point of dedup covers all dispatch
  * sources (observer, listener, future ad-hoc callers).
  */
-class TtsObserverDispatcher
+final class TtsObserverDispatcher
 {
     /**
      * Dispatch `GenerateTtsAudioJob` for every supported locale on every audio

--- a/laravel/app/Services/Tts/TtsObserverDispatcher.php
+++ b/laravel/app/Services/Tts/TtsObserverDispatcher.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace App\Services\Tts;
+
+use App\Contracts\TtsAudioInterface;
+use App\Helpers\ConfigHelper;
+use App\Jobs\Tts\GenerateTtsAudioJob;
+use App\Services\Tts\DTO\TtsAudioContext;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Proactive TTS dispatch logic shared by all model observers.
+ *
+ * The (source → audio_url) field pairs come from the model itself via
+ * `getTtsAudioAttributes()` + `getTtsSourceAttribute()` — relying on the
+ * project-wide `_audio_url` suffix convention. Adding a new translatable
+ * audio field to a model is enough; observer code does not change.
+ *
+ * Per-locale diff for `onUpdated` reads `getRawOriginal()` (bypassing
+ * Spatie's accessor) and compares per supported locale. `onCreated`
+ * short-circuits the diff with an empty original.
+ *
+ * Why no Cache::lock here (unlike GenerateMissingAudioListener):
+ * The listener's lock guards against concurrent READS triggering N duplicate
+ * jobs for the same (model, attribute, locale) — a real race when many users
+ * hit a fresh item simultaneously. Observers fire on WRITE, which is
+ * sequential per row, so there's no race to guard against on the write side.
+ *
+ * Rapid successive admin saves (e.g. typo → fix) will dispatch multiple jobs
+ * for the same key — by design. We accept the extra API call so that the
+ * latest save always wins. Adding a lock here would silently drop the
+ * correction within the lock window, leaving stale audio for the source text.
+ *
+ * Known gap: write↔read race.
+ * Admin save dispatches Job1 (queued); concurrent client read fires the
+ * listener which sees the audio_url still empty and dispatches Job2 — both
+ * jobs synthesize the same text. The atomic JSON_SET in setAudioPath keeps
+ * the DB consistent, but we pay 2× TTS provider quota.
+ *
+ * This is tracked in TTS-BE-01 (centralize dedup at GenerateTtsAudioJob
+ * handle level) and not fixed here because the proper place for the lock is
+ * inside the job itself — that single point of dedup covers all dispatch
+ * sources (observer, listener, future ad-hoc callers).
+ */
+class TtsObserverDispatcher
+{
+    /**
+     * Dispatch `GenerateTtsAudioJob` for every supported locale on every audio
+     * attribute the model exposes — used from `created` callbacks.
+     */
+    public function onCreated(TtsAudioInterface&Model $model): void
+    {
+        foreach ($model->getTtsAudioAttributes() as $audioAttribute) {
+            $sourceAttribute = $model->getTtsSourceAttribute($audioAttribute);
+            $this->dispatchChangedLocales($model, $sourceAttribute, $audioAttribute, []);
+        }
+    }
+
+    /**
+     * Per-locale diff against pre-save raw original — dispatch only for
+     * locales whose value actually changed. Used from `updated` callbacks.
+     */
+    public function onUpdated(TtsAudioInterface&Model $model): void
+    {
+        foreach ($model->getTtsAudioAttributes() as $audioAttribute) {
+            $sourceAttribute = $model->getTtsSourceAttribute($audioAttribute);
+
+            if (! $model->wasChanged($sourceAttribute)) {
+                continue;
+            }
+
+            $this->dispatchChangedLocales(
+                $model,
+                $sourceAttribute,
+                $audioAttribute,
+                $this->decodeOriginal($model, $sourceAttribute),
+            );
+        }
+    }
+
+    /**
+     * @param  array<string, string>  $original
+     */
+    private function dispatchChangedLocales(
+        TtsAudioInterface&Model $model,
+        string $sourceAttribute,
+        string $audioAttribute,
+        array $original,
+    ): void {
+        $supported = ConfigHelper::getStringList('app.supported_locales', ['en']);
+
+        foreach ($supported as $locale) {
+            $value = $model->getTranslatableAttribute($sourceAttribute, $locale);
+
+            if (empty($value)) {
+                continue;
+            }
+
+            if (($original[$locale] ?? null) === $value) {
+                continue;
+            }
+
+            GenerateTtsAudioJob::dispatch(
+                TtsAudioContext::make($model, $audioAttribute, $locale)
+            );
+        }
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function decodeOriginal(Model $model, string $attribute): array
+    {
+        // getRawOriginal bypasses Spatie's translation accessor and returns
+        // the raw JSON string from the DB column as it was before save.
+        $raw = $model->getRawOriginal($attribute);
+
+        if (! is_string($raw) || $raw === '') {
+            return [];
+        }
+
+        $decoded = json_decode($raw, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+}

--- a/laravel/app/Services/Tts/TtsObserverDispatcher.php
+++ b/laravel/app/Services/Tts/TtsObserverDispatcher.php
@@ -92,7 +92,7 @@ class TtsObserverDispatcher
         foreach ($supported as $locale) {
             $value = $model->getTranslatableAttribute($sourceAttribute, $locale);
 
-            if (empty($value)) {
+            if ($value === null || $value === '') {
                 continue;
             }
 

--- a/laravel/app/Services/Tts/TtsObserverDispatcher.php
+++ b/laravel/app/Services/Tts/TtsObserverDispatcher.php
@@ -121,6 +121,12 @@ class TtsObserverDispatcher
 
         $decoded = json_decode($raw, true);
 
-        return is_array($decoded) ? $decoded : [];
+        if (! is_array($decoded)) {
+            return [];
+        }
+
+        // Defend against corrupt JSON (manual SQL, migration bug) — keep only
+        // string values so the declared array<string, string> shape holds.
+        return array_filter($decoded, 'is_string');
     }
 }

--- a/laravel/app/Services/Tts/TtsOrchestrator.php
+++ b/laravel/app/Services/Tts/TtsOrchestrator.php
@@ -51,7 +51,7 @@ class TtsOrchestrator
 
             $text = $model->getTtsText($attribute, $locale);
 
-            if (! $text) {
+            if ($text === null || $text === '') {
                 return;
             }
 
@@ -74,6 +74,6 @@ class TtsOrchestrator
      */
     private function shouldGenerateAudio(?string $audioPath): bool
     {
-        return (empty($audioPath)) && $this->autoGenerateEnabled;
+        return ($audioPath === null || $audioPath === '') && $this->autoGenerateEnabled;
     }
 }

--- a/laravel/app/Traits/HasTtsAudio.php
+++ b/laravel/app/Traits/HasTtsAudio.php
@@ -82,4 +82,27 @@ trait HasTtsAudio
                 "{$attribute}->{$locale}" => $path,
             ]);
     }
+
+    /**
+     * Derive the audio-URL attributes from Spatie's $translatable list by the
+     * `_audio_url` suffix convention (paired with getTtsSourceAttribute).
+     * Models that don't use Spatie's HasTranslations get an empty list — TTS
+     * is opt-in via convention.
+     *
+     * @return array<int, string>
+     */
+    public function getTtsAudioAttributes(): array
+    {
+        if (! property_exists($this, 'translatable')) {
+            return [];
+        }
+
+        /** @var array<int, string> $translatable */
+        $translatable = $this->translatable;
+
+        return array_values(array_filter(
+            $translatable,
+            static fn (string $field): bool => str_ends_with($field, '_audio_url'),
+        ));
+    }
 }

--- a/laravel/app/Traits/HasTtsAudio.php
+++ b/laravel/app/Traits/HasTtsAudio.php
@@ -15,15 +15,23 @@ use Illuminate\Database\Eloquent\Model;
 trait HasTtsAudio
 {
     /**
+     * Suffix appended to source text columns to derive their audio-URL pair.
+     * Project-wide convention: `name` → `name_audio_url`, `title` →
+     * `title_audio_url`, etc. Used by both `getTtsSourceAttribute` (strip)
+     * and `getTtsAudioAttributes` (filter `$translatable`).
+     */
+    private const AUDIO_URL_SUFFIX = '_audio_url';
+
+    /**
      * Get the source text attribute for a given audio attribute.
-     * By default, it removes the '_audio_url' suffix.
+     * By default, it removes the AUDIO_URL_SUFFIX suffix.
      *
      * @param  string  $audioAttribute  Example: 'statement_audio_url'
      * @return string Example: 'statement'
      */
     public function getTtsSourceAttribute(string $audioAttribute): string
     {
-        return str_replace('_audio_url', '', $audioAttribute);
+        return str_replace(self::AUDIO_URL_SUFFIX, '', $audioAttribute);
     }
 
     /**
@@ -102,7 +110,7 @@ trait HasTtsAudio
 
         return array_values(array_filter(
             $translatable,
-            static fn (string $field): bool => str_ends_with($field, '_audio_url'),
+            static fn (string $field): bool => str_ends_with($field, self::AUDIO_URL_SUFFIX),
         ));
     }
 }

--- a/laravel/tests/Feature/Games/FindTheWrong/FindTheWrongTtsObserverTest.php
+++ b/laravel/tests/Feature/Games/FindTheWrong/FindTheWrongTtsObserverTest.php
@@ -19,10 +19,23 @@ class FindTheWrongTtsObserverTest extends TestCase
         Queue::fake();
     }
 
+    /**
+     * Create a level via factory without firing observers — dependency-only
+     * setup, keeps `Queue::assertPushed` counts focused on the unit under test.
+     */
+    private function makeLevelSilently(): FindTheWrongLevel
+    {
+        /** @var FindTheWrongLevel $level */
+        $level = FindTheWrongLevel::withoutEvents(
+            fn () => FindTheWrongLevel::factory()->create()
+        );
+
+        return $level;
+    }
+
     public function test_creating_item_with_all_locales_dispatches_six_jobs(): void
     {
-        $level = FindTheWrongLevel::factory()->create();
-        Queue::fake();
+        $level = $this->makeLevelSilently();
 
         $item = FindTheWrongItem::factory()->create([
             'level_id' => $level->id,
@@ -46,8 +59,7 @@ class FindTheWrongTtsObserverTest extends TestCase
 
     public function test_creating_item_skips_empty_explanation_locales(): void
     {
-        $level = FindTheWrongLevel::factory()->create();
-        Queue::fake();
+        $level = $this->makeLevelSilently();
 
         FindTheWrongItem::factory()->create([
             'level_id' => $level->id,
@@ -67,11 +79,10 @@ class FindTheWrongTtsObserverTest extends TestCase
 
     public function test_updating_only_name_uk_dispatches_one_name_job(): void
     {
-        $item = FindTheWrongItem::factory()->create([
+        $item = $this->makeItemSilently([
             'name' => ['en' => 'Iron', 'uk' => 'Праска', 'es' => 'Plancha'],
             'explanation' => ['en' => 'A', 'uk' => 'Б', 'es' => 'C'],
         ]);
-        Queue::fake();
 
         $item->setTranslation('name', 'uk', 'Новий переклад')->save();
 
@@ -83,10 +94,64 @@ class FindTheWrongTtsObserverTest extends TestCase
         );
     }
 
+    public function test_updating_name_and_explanation_simultaneously_dispatches_two_jobs(): void
+    {
+        $item = $this->makeItemSilently([
+            'name' => ['en' => 'Iron', 'uk' => 'Праска', 'es' => 'Plancha'],
+            'explanation' => ['en' => 'Old', 'uk' => 'Б', 'es' => 'C'],
+        ]);
+
+        $item->setTranslation('name', 'uk', 'Новий переклад')
+            ->setTranslation('explanation', 'en', 'New explanation')
+            ->save();
+
+        Queue::assertPushed(GenerateTtsAudioJob::class, 2);
+        Queue::assertPushed(
+            GenerateTtsAudioJob::class,
+            fn (GenerateTtsAudioJob $job) => $job->context->getAttribute() === 'name_audio_url'
+                && $job->context->getLocale() === 'uk',
+        );
+        Queue::assertPushed(
+            GenerateTtsAudioJob::class,
+            fn (GenerateTtsAudioJob $job) => $job->context->getAttribute() === 'explanation_audio_url'
+                && $job->context->getLocale() === 'en',
+        );
+    }
+
+    public function test_adding_new_locale_dispatches_one_job(): void
+    {
+        $item = $this->makeItemSilently([
+            'name' => ['en' => 'Iron'],
+            'explanation' => ['en' => 'Belongs in laundry'],
+        ]);
+
+        $item->setTranslation('name', 'uk', 'Праска')->save();
+
+        Queue::assertPushed(GenerateTtsAudioJob::class, 1);
+        Queue::assertPushed(
+            GenerateTtsAudioJob::class,
+            fn (GenerateTtsAudioJob $job) => $job->context->getAttribute() === 'name_audio_url'
+                && $job->context->getLocale() === 'uk',
+        );
+    }
+
+    public function test_clearing_locale_dispatches_no_job(): void
+    {
+        $item = $this->makeItemSilently([
+            'name' => ['en' => 'Iron', 'uk' => 'Праска'],
+        ]);
+
+        // Admin clears the uk translation — observer must NOT dispatch TTS
+        // for an empty string. Stale audio for the old "Праска" stays in DB
+        // until cleanup; this test locks in that no-dispatch behavior.
+        $item->setTranslation('name', 'uk', '')->save();
+
+        Queue::assertNothingPushed();
+    }
+
     public function test_updating_non_translated_field_dispatches_no_jobs(): void
     {
-        $item = FindTheWrongItem::factory()->create();
-        Queue::fake();
+        $item = $this->makeItemSilently();
 
         $item->update([
             'polygon' => [[0.1, 0.1], [0.9, 0.1], [0.9, 0.9], [0.1, 0.9]],
@@ -97,10 +162,9 @@ class FindTheWrongTtsObserverTest extends TestCase
 
     public function test_updating_name_to_same_values_dispatches_no_jobs(): void
     {
-        $item = FindTheWrongItem::factory()->create([
+        $item = $this->makeItemSilently([
             'name' => ['en' => 'Iron', 'uk' => 'Праска', 'es' => 'Plancha'],
         ]);
-        Queue::fake();
 
         $item->setTranslations('name', ['en' => 'Iron', 'uk' => 'Праска', 'es' => 'Plancha'])->save();
 
@@ -127,10 +191,9 @@ class FindTheWrongTtsObserverTest extends TestCase
 
     public function test_updating_level_title_uk_dispatches_one_job(): void
     {
-        $level = FindTheWrongLevel::factory()->create([
-            'title' => ['en' => 'Kitchen', 'uk' => 'Кухня', 'es' => 'Cocina'],
-        ]);
-        Queue::fake();
+        $level = $this->makeLevelSilently();
+        $level->setTranslations('title', ['en' => 'Kitchen', 'uk' => 'Кухня', 'es' => 'Cocina']);
+        $level->saveQuietly();
 
         $level->setTranslation('title', 'uk', 'Нова кухня')->save();
 
@@ -144,11 +207,31 @@ class FindTheWrongTtsObserverTest extends TestCase
 
     public function test_updating_level_image_only_dispatches_no_jobs(): void
     {
-        $level = FindTheWrongLevel::factory()->create();
-        Queue::fake();
+        $level = $this->makeLevelSilently();
 
         $level->update(['image_url' => 'games/find-the-wrong/levels/other.jpg']);
 
         Queue::assertNothingPushed();
+    }
+
+    /**
+     * Persist an item (and its parent level) without firing any observers,
+     * so subsequent `setTranslation()->save()` is the only event under test.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    private function makeItemSilently(array $attributes = []): FindTheWrongItem
+    {
+        $level = $this->makeLevelSilently();
+
+        /** @var FindTheWrongItem $item */
+        $item = FindTheWrongItem::withoutEvents(
+            fn () => FindTheWrongItem::factory()->create([
+                'level_id' => $level->id,
+                ...$attributes,
+            ])
+        );
+
+        return $item;
     }
 }

--- a/laravel/tests/Feature/Games/FindTheWrong/FindTheWrongTtsObserverTest.php
+++ b/laravel/tests/Feature/Games/FindTheWrong/FindTheWrongTtsObserverTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Tests\Feature\Games\FindTheWrong;
+
+use App\Games\FindTheWrong\Models\FindTheWrongItem;
+use App\Games\FindTheWrong\Models\FindTheWrongLevel;
+use App\Jobs\Tts\GenerateTtsAudioJob;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class FindTheWrongTtsObserverTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Queue::fake();
+    }
+
+    public function test_creating_item_with_all_locales_dispatches_six_jobs(): void
+    {
+        $level = FindTheWrongLevel::factory()->create();
+        Queue::fake();
+
+        $item = FindTheWrongItem::factory()->create([
+            'level_id' => $level->id,
+            'name' => ['en' => 'Iron', 'uk' => 'Праска', 'es' => 'Plancha'],
+            'explanation' => ['en' => 'Belongs in laundry', 'uk' => 'Не на кухні', 'es' => 'Pertenece a lavandería'],
+        ]);
+
+        Queue::assertPushed(GenerateTtsAudioJob::class, 6);
+
+        foreach (['en', 'uk', 'es'] as $locale) {
+            foreach (['name_audio_url', 'explanation_audio_url'] as $attribute) {
+                Queue::assertPushed(
+                    GenerateTtsAudioJob::class,
+                    fn (GenerateTtsAudioJob $job) => $job->context->getModel()->is($item)
+                        && $job->context->getAttribute() === $attribute
+                        && $job->context->getLocale() === $locale,
+                );
+            }
+        }
+    }
+
+    public function test_creating_item_skips_empty_explanation_locales(): void
+    {
+        $level = FindTheWrongLevel::factory()->create();
+        Queue::fake();
+
+        FindTheWrongItem::factory()->create([
+            'level_id' => $level->id,
+            'name' => ['en' => 'Iron', 'uk' => 'Праска', 'es' => 'Plancha'],
+            'explanation' => ['en' => 'Belongs in laundry', 'uk' => '', 'es' => ''],
+        ]);
+
+        // 3 jobs for name + 1 for explanation (only en) = 4
+        Queue::assertPushed(GenerateTtsAudioJob::class, 4);
+
+        Queue::assertNotPushed(
+            GenerateTtsAudioJob::class,
+            fn (GenerateTtsAudioJob $job) => $job->context->getAttribute() === 'explanation_audio_url'
+                && in_array($job->context->getLocale(), ['uk', 'es'], true),
+        );
+    }
+
+    public function test_updating_only_name_uk_dispatches_one_name_job(): void
+    {
+        $item = FindTheWrongItem::factory()->create([
+            'name' => ['en' => 'Iron', 'uk' => 'Праска', 'es' => 'Plancha'],
+            'explanation' => ['en' => 'A', 'uk' => 'Б', 'es' => 'C'],
+        ]);
+        Queue::fake();
+
+        $item->setTranslation('name', 'uk', 'Новий переклад')->save();
+
+        Queue::assertPushed(GenerateTtsAudioJob::class, 1);
+        Queue::assertPushed(
+            GenerateTtsAudioJob::class,
+            fn (GenerateTtsAudioJob $job) => $job->context->getAttribute() === 'name_audio_url'
+                && $job->context->getLocale() === 'uk',
+        );
+    }
+
+    public function test_updating_non_translated_field_dispatches_no_jobs(): void
+    {
+        $item = FindTheWrongItem::factory()->create();
+        Queue::fake();
+
+        $item->update([
+            'polygon' => [[0.1, 0.1], [0.9, 0.1], [0.9, 0.9], [0.1, 0.9]],
+        ]);
+
+        Queue::assertNothingPushed();
+    }
+
+    public function test_updating_name_to_same_values_dispatches_no_jobs(): void
+    {
+        $item = FindTheWrongItem::factory()->create([
+            'name' => ['en' => 'Iron', 'uk' => 'Праска', 'es' => 'Plancha'],
+        ]);
+        Queue::fake();
+
+        $item->setTranslations('name', ['en' => 'Iron', 'uk' => 'Праска', 'es' => 'Plancha'])->save();
+
+        Queue::assertNothingPushed();
+    }
+
+    public function test_creating_level_dispatches_one_job_per_locale(): void
+    {
+        $level = FindTheWrongLevel::factory()->create([
+            'title' => ['en' => 'Kitchen', 'uk' => 'Кухня', 'es' => 'Cocina'],
+        ]);
+
+        Queue::assertPushed(GenerateTtsAudioJob::class, 3);
+
+        foreach (['en', 'uk', 'es'] as $locale) {
+            Queue::assertPushed(
+                GenerateTtsAudioJob::class,
+                fn (GenerateTtsAudioJob $job) => $job->context->getModel()->is($level)
+                    && $job->context->getAttribute() === 'title_audio_url'
+                    && $job->context->getLocale() === $locale,
+            );
+        }
+    }
+
+    public function test_updating_level_title_uk_dispatches_one_job(): void
+    {
+        $level = FindTheWrongLevel::factory()->create([
+            'title' => ['en' => 'Kitchen', 'uk' => 'Кухня', 'es' => 'Cocina'],
+        ]);
+        Queue::fake();
+
+        $level->setTranslation('title', 'uk', 'Нова кухня')->save();
+
+        Queue::assertPushed(GenerateTtsAudioJob::class, 1);
+        Queue::assertPushed(
+            GenerateTtsAudioJob::class,
+            fn (GenerateTtsAudioJob $job) => $job->context->getAttribute() === 'title_audio_url'
+                && $job->context->getLocale() === 'uk',
+        );
+    }
+
+    public function test_updating_level_image_only_dispatches_no_jobs(): void
+    {
+        $level = FindTheWrongLevel::factory()->create();
+        Queue::fake();
+
+        $level->update(['image_url' => 'games/find-the-wrong/levels/other.jpg']);
+
+        Queue::assertNothingPushed();
+    }
+}

--- a/laravel/tests/Feature/Games/FindTheWrong/FindTheWrongTtsObserverTest.php
+++ b/laravel/tests/Feature/Games/FindTheWrong/FindTheWrongTtsObserverTest.php
@@ -49,9 +49,9 @@ class FindTheWrongTtsObserverTest extends TestCase
             foreach (['name_audio_url', 'explanation_audio_url'] as $attribute) {
                 Queue::assertPushed(
                     GenerateTtsAudioJob::class,
-                    fn (GenerateTtsAudioJob $job) => $job->context->getModel()->is($item)
-                        && $job->context->getAttribute() === $attribute
-                        && $job->context->getLocale() === $locale,
+                    fn (GenerateTtsAudioJob $job) => $job->model->is($item)
+                        && $job->attribute === $attribute
+                        && $job->locale === $locale,
                 );
             }
         }
@@ -72,8 +72,8 @@ class FindTheWrongTtsObserverTest extends TestCase
 
         Queue::assertNotPushed(
             GenerateTtsAudioJob::class,
-            fn (GenerateTtsAudioJob $job) => $job->context->getAttribute() === 'explanation_audio_url'
-                && in_array($job->context->getLocale(), ['uk', 'es'], true),
+            fn (GenerateTtsAudioJob $job) => $job->attribute === 'explanation_audio_url'
+                && in_array($job->locale, ['uk', 'es'], true),
         );
     }
 
@@ -89,8 +89,8 @@ class FindTheWrongTtsObserverTest extends TestCase
         Queue::assertPushed(GenerateTtsAudioJob::class, 1);
         Queue::assertPushed(
             GenerateTtsAudioJob::class,
-            fn (GenerateTtsAudioJob $job) => $job->context->getAttribute() === 'name_audio_url'
-                && $job->context->getLocale() === 'uk',
+            fn (GenerateTtsAudioJob $job) => $job->attribute === 'name_audio_url'
+                && $job->locale === 'uk',
         );
     }
 
@@ -108,13 +108,13 @@ class FindTheWrongTtsObserverTest extends TestCase
         Queue::assertPushed(GenerateTtsAudioJob::class, 2);
         Queue::assertPushed(
             GenerateTtsAudioJob::class,
-            fn (GenerateTtsAudioJob $job) => $job->context->getAttribute() === 'name_audio_url'
-                && $job->context->getLocale() === 'uk',
+            fn (GenerateTtsAudioJob $job) => $job->attribute === 'name_audio_url'
+                && $job->locale === 'uk',
         );
         Queue::assertPushed(
             GenerateTtsAudioJob::class,
-            fn (GenerateTtsAudioJob $job) => $job->context->getAttribute() === 'explanation_audio_url'
-                && $job->context->getLocale() === 'en',
+            fn (GenerateTtsAudioJob $job) => $job->attribute === 'explanation_audio_url'
+                && $job->locale === 'en',
         );
     }
 
@@ -130,8 +130,8 @@ class FindTheWrongTtsObserverTest extends TestCase
         Queue::assertPushed(GenerateTtsAudioJob::class, 1);
         Queue::assertPushed(
             GenerateTtsAudioJob::class,
-            fn (GenerateTtsAudioJob $job) => $job->context->getAttribute() === 'name_audio_url'
-                && $job->context->getLocale() === 'uk',
+            fn (GenerateTtsAudioJob $job) => $job->attribute === 'name_audio_url'
+                && $job->locale === 'uk',
         );
     }
 
@@ -182,9 +182,9 @@ class FindTheWrongTtsObserverTest extends TestCase
         foreach (['en', 'uk', 'es'] as $locale) {
             Queue::assertPushed(
                 GenerateTtsAudioJob::class,
-                fn (GenerateTtsAudioJob $job) => $job->context->getModel()->is($level)
-                    && $job->context->getAttribute() === 'title_audio_url'
-                    && $job->context->getLocale() === $locale,
+                fn (GenerateTtsAudioJob $job) => $job->model->is($level)
+                    && $job->attribute === 'title_audio_url'
+                    && $job->locale === $locale,
             );
         }
     }
@@ -200,8 +200,8 @@ class FindTheWrongTtsObserverTest extends TestCase
         Queue::assertPushed(GenerateTtsAudioJob::class, 1);
         Queue::assertPushed(
             GenerateTtsAudioJob::class,
-            fn (GenerateTtsAudioJob $job) => $job->context->getAttribute() === 'title_audio_url'
-                && $job->context->getLocale() === 'uk',
+            fn (GenerateTtsAudioJob $job) => $job->attribute === 'title_audio_url'
+                && $job->locale === 'uk',
         );
     }
 

--- a/laravel/tests/TestCase.php
+++ b/laravel/tests/TestCase.php
@@ -3,10 +3,24 @@
 namespace Tests;
 
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Illuminate\Support\Facades\Queue;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
     use MockeryPHPUnitIntegration;
+
+    /**
+     * Fake the queue by default so model observers that dispatch jobs (TTS,
+     * etc.) don't trigger synchronous job execution under QUEUE_CONNECTION=sync.
+     * Tests that assert on dispatched jobs (Queue::assertPushed) work as-is
+     * because Queue::fake() can be called repeatedly; tests that need real
+     * queue behavior would have to opt out explicitly.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Queue::fake();
+    }
 }

--- a/laravel/tests/Unit/Jobs/Tts/GenerateTtsAudioJobTest.php
+++ b/laravel/tests/Unit/Jobs/Tts/GenerateTtsAudioJobTest.php
@@ -33,12 +33,12 @@ class GenerateTtsAudioJobTest extends TestCase
         config(['ai.tts.auto_generate.queue' => 'tts']);
     }
 
-    private function createContext(): TtsAudioContext
+    private function createJob(): GenerateTtsAudioJob
     {
         $model = $this->createMock(JobTtsMockModel::class);
         $model->method('getKey')->willReturn(1);
 
-        return new TtsAudioContext($model, 'statement_audio_url', 'uk', 'Текст');
+        return new GenerateTtsAudioJob($model, 'statement_audio_url', 'uk', 'Текст');
     }
 
     // ──────────────────────────────────────────────
@@ -47,13 +47,16 @@ class GenerateTtsAudioJobTest extends TestCase
 
     public function test_calls_generate_for_model_and_logs_info(): void
     {
-        $context = $this->createContext();
-        $job = new GenerateTtsAudioJob($context);
+        $job = $this->createJob();
 
         $this->audioGenerator
             ->expects($this->once())
             ->method('generateForModel')
-            ->with($context);
+            ->with($this->callback(
+                fn (TtsAudioContext $context) => $context->getAttribute() === 'statement_audio_url'
+                    && $context->getLocale() === 'uk'
+                    && $context->getText() === 'Текст'
+            ));
 
         $this->logger
             ->expects($this->once())
@@ -68,11 +71,12 @@ class GenerateTtsAudioJobTest extends TestCase
 
     public function test_releases_job_on_quota_exceeded(): void
     {
-        $context = $this->createContext();
+        $model = $this->createMock(JobTtsMockModel::class);
+        $model->method('getKey')->willReturn(1);
 
         /** @var GenerateTtsAudioJob&MockObject $job */
         $job = $this->getMockBuilder(GenerateTtsAudioJob::class)
-            ->setConstructorArgs([$context])
+            ->setConstructorArgs([$model, 'statement_audio_url', 'uk', 'Текст'])
             ->onlyMethods(['release', 'attempts'])
             ->getMock();
 
@@ -102,8 +106,7 @@ class GenerateTtsAudioJobTest extends TestCase
 
     public function test_rethrows_on_generic_throwable(): void
     {
-        $context = $this->createContext();
-        $job = new GenerateTtsAudioJob($context);
+        $job = $this->createJob();
 
         $this->audioGenerator
             ->method('generateForModel')


### PR DESCRIPTION
- [x] Add `getTtsAudioAttributes(): array` to `TtsAudioInterface` contract; implement in `HasTtsAudio` trait by filtering `$translatable` by `_audio_url` suffix
- [x] Create `TtsObserverDispatcher`
- [x] Create ``ProactiveTtsObserver``
- [x] Register observer for `FindTheWrongItem` and `FindTheWrongLevel` in `EventServiceProvider::$observers`
- [x] Create feature tests